### PR TITLE
VM: add some optional callbacks

### DIFF
--- a/vm/vm.c
+++ b/vm/vm.c
@@ -100,6 +100,8 @@ static sint16 AsebaVMDoBinaryOperation(AsebaVMState *vm, sint16 valueOne, sint16
 			// check division by zero
 			if (valueTwo == 0)
 			{
+				if(AsebaVMErrorCB)
+					AsebaVMErrorCB(vm,NULL);
 				vm->flags = ASEBA_VM_STEP_BY_STEP_MASK;
 				AsebaSendMessageWords(vm, ASEBA_MESSAGE_DIVISION_BY_ZERO, &vm->pc, 1);
 				return 0;
@@ -273,6 +275,8 @@ void AsebaVMStep(AsebaVMState *vm)
 				buffer[2] = variableIndex;
 				vm->flags = ASEBA_VM_STEP_BY_STEP_MASK;
 				AsebaSendMessage(vm, ASEBA_MESSAGE_ARRAY_ACCESS_OUT_OF_BOUNDS, buffer, 3);
+				if(AsebaVMErrorCB)
+					AsebaVMErrorCB(vm,NULL);
 				break;
 			}
 			
@@ -313,6 +317,8 @@ void AsebaVMStep(AsebaVMState *vm)
 				buffer[2] = variableIndex;
 				vm->flags = ASEBA_VM_STEP_BY_STEP_MASK;
 				AsebaSendMessageWords(vm, ASEBA_MESSAGE_ARRAY_ACCESS_OUT_OF_BOUNDS, buffer, 3);
+				if(AsebaVMErrorCB)
+					AsebaVMErrorCB(vm,NULL);
 				break;
 			}
 			
@@ -509,6 +515,9 @@ void AsebaVMEmitNodeSpecificError(AsebaVMState *vm, const char* message)
 #else
 	#error "Please provide a stack memory allocator for your compiler"
 #endif
+	
+	if (AsebaVMErrorCB)
+		AsebaVMErrorCB(vm, message);
 	
 	vm->flags = ASEBA_VM_STEP_BY_STEP_MASK;
 	
@@ -727,6 +736,8 @@ void AsebaVMDebugMessage(AsebaVMState *vm, uint16 id, uint16 *data, uint16 dataL
 		case ASEBA_MESSAGE_RUN:
 		AsebaMaskClear(vm->flags, ASEBA_VM_STEP_BY_STEP_MASK);
 		AsebaVMSendExecutionStateChanged(vm);
+		if(AsebaVMRunCB)
+			AsebaVMRunCB(vm);
 		break;
 		
 		case ASEBA_MESSAGE_PAUSE:

--- a/vm/vm.h
+++ b/vm/vm.h
@@ -171,6 +171,13 @@ void AsebaResetIntoBootloader(AsebaVMState *vm);
 /*! Called by AsebaVMDebugMessage when VM must put to node in deep sleep. Write an empty function to leave feature unsupported */
 void AsebaPutVmToSleep(AsebaVMState *vm);
 
+/*! Called by AsebaVMDebugMessage when VM is going to be run */
+void __attribute__((weak)) AsebaVMRunCB(AsebaVMState *vm);
+
+/*! Called by AsebaVMEmitNodeSpecificError to be notified when VM hit an execution error
+	Is also called for wrong array access or division by 0 with message == NULL */
+void __attribute__((weak)) AsebaVMErrorCB(AsebaVMState *vm, const char* message);
+
 // Function optionally implemented
 
 #ifdef ASEBA_ASSERT


### PR DESCRIPTION
This commit add two callbacks, one which is called every time the
VM get a "run" message, this enable to track each time the user
hit the run button in asebastudio.
The second one tracks each time the VM is encountering an user
programming error, such as division by 0, out of array access or wrong
native function use.

This is used on the next thymio II firmware. So please pull it or propose another way to have the same features :)
