### PR TITLE
can-net: Fix compiler bug on 16bits PICs 

### DIFF
--- a/transport/can/can-net.c
+++ b/transport/can/can-net.c
@@ -402,7 +402,7 @@ void AsebaCanFrameReceived(const CanFrame *frame)
 	{
 		uint16 temp;
 		// store and increment pos
-		asebaCan.recvQueue[asebaCan.recvQueueInsertPos] = *frame;
+		memcpy(&asebaCan.recvQueue[asebaCan.recvQueueInsertPos], frame, sizeof(*frame));
 		asebaCan.recvQueue[asebaCan.recvQueueInsertPos].used = 1;
 		temp = asebaCan.recvQueueInsertPos + 1;
 		if (temp >= asebaCan.recvQueueSize)


### PR DESCRIPTION
The compiler provided by "Mplab X" wrongly optimize the structure copy
by corrupting data (dropping the first 2 bytes).

Fix this by using memcpy.
