### PR TITLE
compiler: Fix emit statment when using a simple variable as argument

### DIFF
--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -687,6 +687,7 @@ namespace Aseba
 		if (eventSize > 0)
 		{
 			std::auto_ptr<Node> preNode(parseBinaryOrExpression());
+			bool memoryAllocated = false;
 
 			// allocate memory?
 			if (!dynamic_cast<MemoryVectorNode*>(preNode.get()) || preNode->getVectorAddr() == Node::E_NOVAL)
@@ -695,12 +696,17 @@ namespace Aseba
 				preNode.release();
 				preNode.reset(temp);
 				emitNode->children.push_back(preNode.get());
+				memoryAllocated = true;
 			}
 
 			//allocateTemporaryVariable(pos)
 			emitNode->arrayAddr = preNode->getVectorAddr();
 			emitNode->arraySize = preNode->getVectorSize();
-			preNode.release();
+
+			if (memoryAllocated)
+				preNode.release();
+			else
+				preNode.reset(); // we do not need a pointer to it anymore
 
 			if (emitNode->arraySize != eventSize)
 				throw TranslatableError(pos, ERROR_EVENT_WRONG_ARG_SIZE).arg(commonDefinitions->events[emitNode->eventId].name).arg(eventSize).arg(emitNode->arraySize);


### PR DESCRIPTION
When using

emit foo bar

with bar being a 'simple' variable (i.e. we do not need to perform
temporary memory allocations), the current intermediate tree looks
like

EmitNode(foo)
      |
      --- MemoryVectorNode(bar)

which is wrong, as EmitNode's child nodes should only be used when
temporary memory allocation is necessary. As a result, the bytecode
for MemoryVectorNode will be emitted, resulting in a spurious LOAD
operation:

LOAD 35
EMIT foo addr 35 size 1

This spurious LOAD can potentially currupt Aseba's stack, which in turn
can have suprising effect when happening inside a subroutine call.

The fix is simple: add the MemoryVectorNode as a child of EmitNode only
if it is a temporary memory allocation. Only in such case, the emitted
bytecode will be correct, with balanced LOAD/STORE operations.
