### PR TITLE
Update README with script from wiki

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,21 +35,23 @@ Then you have to fetch Dashel, Enki, compile them, and then you can fetch Aseba 
 	mkdir -p aseba/build-dashel aseba/build-enki aseba/build-aseba
 	cd aseba
 	# fetch and compile dashel
-	git clone https://github.com/aseba-community/dashel.git
+	git clone git://github.com/aseba-community/dashel.git
 	cd build-dashel
-	cmake ../dashel -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=OFF
+	cmake ../dashel -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON
 	make
 	cd ..
 	# fetch and compile enki
-	git clone https://github.com/enki-community/enki.git
+	git clone git://github.com/enki-community/enki.git
 	cd build-enki
 	cmake ../enki -DCMAKE_BUILD_TYPE=RelWithDebInfo
 	make
 	cd ..
 	# fetch and compile aseba, telling it where to find dashel and enki
-	git clone https://github.com/aseba-community/aseba.git
+	git clone git://github.com/aseba-community/aseba.git
+	cd aseba && git checkout release-1.3.x && cd ..
 	cd build-aseba
-	cmake ../aseba -DCMAKE_BUILD_TYPE=RelWithDebInfo -Ddashel_DIR=../build-dashel -DDASHEL_INCLUDE_DIR=../dashel -DDASHEL_LIBRARY=../build-dashel/libdashel.a -DENKI_INCLUDE_DIR=../enki -DENKI_LIBRARY=../build-enki/enki/libenki.a -DENKI_VIEWER_LIBRARY=../build-enki/viewer/libenkiviewer.a
+	export dashel_DIR=../build-dashel
+	cmake ../aseba -DCMAKE_BUILD_TYPE=RelWithDebInfo -Ddashel_DIR=../build-dashel -DDASHEL_INCLUDE_DIR=../dashel -DDASHEL_LIBRARY=../build-dashel/libdashel.so -DENKI_INCLUDE_DIR=../enki -DENKI_LIBRARY=../build-enki/enki/libenki.a -DENKI_VIEWER_LIBRARY=../build-enki/viewer/libenkiviewer.a
 	make
 
 Once this script has run, you can find the executables in `build-aseba/`, in their respective sub-directories. 

--- a/readme.md
+++ b/readme.md
@@ -35,23 +35,22 @@ Then you have to fetch Dashel, Enki, compile them, and then you can fetch Aseba 
 	mkdir -p aseba/build-dashel aseba/build-enki aseba/build-aseba
 	cd aseba
 	# fetch and compile dashel
-	git clone git://github.com/aseba-community/dashel.git
+	git clone https://github.com/aseba-community/dashel.git
 	cd build-dashel
-	cmake ../dashel -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON
+	cmake ../dashel -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=OFF
 	make
 	cd ..
 	# fetch and compile enki
-	git clone git://github.com/enki-community/enki.git
+	git clone https://github.com/enki-community/enki.git
 	cd build-enki
 	cmake ../enki -DCMAKE_BUILD_TYPE=RelWithDebInfo
 	make
 	cd ..
 	# fetch and compile aseba, telling it where to find dashel and enki
-	git clone git://github.com/aseba-community/aseba.git
-	cd aseba && git checkout release-1.3.x && cd ..
+	git clone https://github.com/aseba-community/aseba.git
 	cd build-aseba
 	export dashel_DIR=../build-dashel
-	cmake ../aseba -DCMAKE_BUILD_TYPE=RelWithDebInfo -Ddashel_DIR=../build-dashel -DDASHEL_INCLUDE_DIR=../dashel -DDASHEL_LIBRARY=../build-dashel/libdashel.so -DENKI_INCLUDE_DIR=../enki -DENKI_LIBRARY=../build-enki/enki/libenki.a -DENKI_VIEWER_LIBRARY=../build-enki/viewer/libenkiviewer.a
+	cmake ../aseba -DCMAKE_BUILD_TYPE=RelWithDebInfo -Ddashel_DIR=../build-dashel -DDASHEL_INCLUDE_DIR=../dashel -DDASHEL_LIBRARY=../build-dashel/libdashel.a -DENKI_INCLUDE_DIR=../enki -DENKI_LIBRARY=../build-enki/enki/libenki.a -DENKI_VIEWER_LIBRARY=../build-enki/viewer/libenkiviewer.a
 	make
 
 Once this script has run, you can find the executables in `build-aseba/`, in their respective sub-directories. 


### PR DESCRIPTION
Hi, I just want to share my experience that running the script displayed on the readme on github did not work right away and using the script available on the wiki : https://aseba.wikidot.com/en:sourceinstall worked directly, hence the suggested update.

One more suggestion: how about making this into a script at the root of the project ?