### PR TITLE
asebahttp connects Aseba with HTTP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/externals/Catch"]
+	path = tests/externals/Catch
+	url = https://github.com/philsquared/Catch

--- a/examples/http/node-red/thymio-breathe.json
+++ b/examples/http/node-red/thymio-breathe.json
@@ -1,0 +1,126 @@
+[
+  {
+    "id": "578e9f0f.a8716",
+    "type": "inject",
+    "name": "every minute",
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "repeat": "",
+    "crontab": "*\/1 * * * *",
+    "once": false,
+    "x": 100,
+    "y": 240,
+    "z": "460ba41.fb9f45c",
+    "wires": [
+      [
+        "93eb914c.6c147"
+      ]
+    ]
+  },
+  {
+    "id": "93eb914c.6c147",
+    "type": "http request",
+    "name": "beep thymio-II",
+    "method": "GET",
+    "url": "http:\/\/127.0.0.1:3000\/nodes\/thymio-II\/A_sound_system\/8",
+    "x": 300,
+    "y": 180,
+    "z": "460ba41.fb9f45c",
+    "wires": [
+      [
+        "24eb13b2.db14ec"
+      ]
+    ]
+  },
+  {
+    "id": "1a145ef5.e5eba1",
+    "type": "inject",
+    "name": "300 msec",
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "repeat": "0.3",
+    "crontab": "",
+    "once": true,
+    "x": 100,
+    "y": 60,
+    "z": "460ba41.fb9f45c",
+    "wires": [
+      [
+        "1d14413.fe2ebbf"
+      ]
+    ]
+  },
+  {
+    "id": "1d14413.fe2ebbf",
+    "type": "function",
+    "name": "breathe leds",
+    "func": "var tick = Math.floor(msg.payload \/ 300) % 13;\nmsg.green = tick<5            ?  8 + 8*(3-Math.abs(tick-2))  : 0;\nmsg.red   = tick>2 && tick<7  ?      5*(3-Math.abs(tick-4))  : 0;\nmsg.blue = 0;\nmsg.payload = \"rgb=(\"+ msg.red +\" \"+ msg.green +\" \"+ msg.blue +\")\";\nreturn msg;",
+    "outputs": 1,
+    "x": 300,
+    "y": 60,
+    "z": "460ba41.fb9f45c",
+    "wires": [
+      [
+        "e8c06fe3.173f9",
+        "fd51c6b5.02ae38"
+      ]
+    ]
+  },
+  {
+    "id": "e8c06fe3.173f9",
+    "type": "http request",
+    "name": "top leds thymio-II",
+    "method": "GET",
+    "url": "http:\/\/127.0.0.1:3000\/nodes\/thymio-II\/V_leds_top\/{{red}}\/{{green}}\/{{blue}}",
+    "x": 500,
+    "y": 60,
+    "z": "460ba41.fb9f45c",
+    "wires": [
+      [
+        
+      ]
+    ]
+  },
+  {
+    "id": "fd51c6b5.02ae38",
+    "type": "debug",
+    "name": "debug RGB",
+    "active": false,
+    "console": "false",
+    "complete": "false",
+    "x": 500,
+    "y": 120,
+    "z": "460ba41.fb9f45c",
+    "wires": [
+      
+    ]
+  },
+  {
+    "id": "7e30981a.81cf68",
+    "type": "http in",
+    "name": "",
+    "url": "\/beep",
+    "method": "get",
+    "x": 100,
+    "y": 180,
+    "z": "460ba41.fb9f45c",
+    "wires": [
+      [
+        "93eb914c.6c147"
+      ]
+    ]
+  },
+  {
+    "id": "24eb13b2.db14ec",
+    "type": "http response",
+    "name": "http ack",
+    "x": 500,
+    "y": 180,
+    "z": "460ba41.fb9f45c",
+    "wires": [
+      
+    ]
+  }
+]

--- a/switches/CMakeLists.txt
+++ b/switches/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(switch)
 add_subdirectory(medulla)
 add_subdirectory(botspeak)
+add_subdirectory(http)

--- a/switches/http/CMakeLists.txt
+++ b/switches/http/CMakeLists.txt
@@ -1,0 +1,45 @@
+# asebahttp - a switch to bridge HTTP to Aseba
+# 2014-12-01 David James Sherman <david dot sherman at inria dot fr>
+
+# need libxml2 to read aesl files
+find_package(LibXml2)
+if (LIBXML2_FOUND)
+	
+        include_directories(${LIBXML2_INCLUDE_DIR})
+
+	set(http_SRCS
+		http.cpp
+		main.cpp
+	)
+	set(http_MOCS
+		http.h
+	)
+	
+	add_executable(asebahttp ${http_SRCS} ${http_MOCS})
+	
+	target_link_libraries(asebahttp asebacompiler asebacommon ${LIBXML2_LIBRARIES} ${ASEBA_CORE_LIBRARIES})
+
+	install(TARGETS asebahttp RUNTIME
+		DESTINATION bin
+	)
+
+	add_library(asebahttphub ${http_SRCS})
+	set_target_properties(asebahttphub PROPERTIES VERSION ${LIB_VERSION_STRING} 
+						    SOVERSION ${LIB_VERSION_MAJOR})
+
+	install(TARGETS asebahttphub
+			LIBRARY DESTINATION ${LIB_INSTALL_DIR} 
+			ARCHIVE DESTINATION ${LIB_INSTALL_DIR} 
+	)
+
+	set (ASEBACORE_HDR_HTTP
+		http.h
+	)
+	install(FILES ${ASEBACORE_HDR_HTTP}
+		DESTINATION include/aseba/switches/http
+	)
+
+	configure_file(dummynode-1-tick.aesl ${CMAKE_CURRENT_BINARY_DIR}/dummynode-1-tick.aesl COPYONLY)
+	configure_file(dummynode-1.aesl ${CMAKE_CURRENT_BINARY_DIR}/dummynode-1.aesl COPYONLY)
+
+endif (LIBXML2_FOUND)

--- a/switches/http/README.md
+++ b/switches/http/README.md
@@ -1,0 +1,75 @@
+asebahttp - a switch to bridge Aseba to HTTP
+
+2015-01-01 David James Sherman <david dot sherman at inria dot fr>
+
+Provide a simple REST interface with introspection for Aseba devices.
+
+- GET  /nodes                                 - JSON list of all known nodes
+- GET  /nodes/:NODENAME                       - JSON attributes for :NODENAME
+- PUT  /nodes/:NODENAME                       - write new Aesl program (file= in multipart/form-data)
+- GET  /nodes/:NODENAME/:VARIABLE             - retrieve JSON value for :VARIABLE
+- POST /nodes/:NODENAME/:VARIABLE             - send new values(s) for :VARIABLE
+- POST /nodes/:NODENAME/:EVENT                - call an event :EVENT
+- GET  /events\[/:EVENT\]*                      - create SSE stream for all known nodes
+- GET  /nodes/:NODENAME/events\[/:EVENT\]*      - create SSE stream for :NODENAME
+
+Typical use: `asebahttp --port 3000 --aesl vmcode.aesl ser:name=Thymio-II &`
+After vmcode.aesl is compiled and uploaded, check with `curl http://127.0.0.1:3000/nodes/thymio-II`
+                
+Substitute appropriate values for :NODENAME, :VARIABLE, :EVENT and their parameters. In most cases,
+:NODENAME is `thymio-II`) For example.
+- `curl http://localhost:3000/nodes/thymio-II/motor.left.target/100`
+  sets the speed of the left motor
+- `curl http://nodes/thymio-II/sound_system/4/10`
+  might record sound number 4 for 10 seconds, if such an event were defined in AESL.
+                
+Variables and events are learned from the node description and parsed from AESL source when provided.
+Server-side event (SSE) streams are updated as events arrive.
+If a variable and an event have the same name, it is the EVENT that is called.
+On a local machine the server can handle 600 requests/sec with 10 concurrent connections,
+more (up to 2.5 times more) if the requests are pipelined as is the HTTP/1.1 default.
+
+Start an 'asebadummynode 0' and run 'make test' to execute some basic unit tests.
+Example [Node-RED](http://nodered.org) flows can be found in ../../examples/http/node-red.
+
+DONE:
+- Dashel connection to one Thymio-II and round-robin scheduling between Aseba and HTTP connections
+- read Aesl program at launch, upload to Thymio-II, and record interface for introspection
+- GET /nodes, GET /nodes/:NODENAME with introspection
+- POST /nodes/:NODENAME/:VARIABLE (sloppily allows GET /nodes/:NODENAME/:VARIABLE/:VALUE\[/:VALUE\]*)
+- POST /nodes/:NODENAME/:EVENT (sloppily allows GET /nodes/:NODENAME/:EVENT\[/:VALUE\]*)
+- form processing for updates and events (POST /.../:VARIABLE) and (POST /.../:EVENT)
+- handle asynchronous variable reporting (GET /nodes/:NODENAME/:VARIABLE)
+- JSON format for variable reporting (GET /nodes/:NODENAME/:VARIABLE)
+- implement SSE streams and event filtering (GET /events) and (GET /nodes/:NODENAME/events)
+- Aesl program bytecode upload (PUT /nodes/:NODENAME)
+  use curl --data-ascii "file=$(cat vmcode.aesl)" -X PUT http://127.0.0.1:3000/nodes/thymio-II
+- accept JSON payload rather than HTML form for updates and events (POST /.../:VARIABLE) and (POST /.../:EVENT)
+
+TODO:
+- handle more than just one Thymio-II node
+- gracefully shut down TCP/IP connections (half-close, wait, close)
+
+This code borrows from the rest of Aseba, especially switches/medulla and examples/clients/cpp-shell,
+which bear the copyright and LGPL 3 licensing notice below.
+
+
+/*
+Aseba - an event-based framework for distributed robot control
+Copyright (C) 2007--2015:
+Stephane Magnenat <stephane at magnenat dot net>
+(http://stephane.magnenat.net)
+and other contributors, see authors.txt for details
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published
+by the Free Software Foundation, version 3 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/

--- a/switches/http/dummynode-1-tick.aesl
+++ b/switches/http/dummynode-1-tick.aesl
@@ -1,0 +1,31 @@
+<!DOCTYPE aesl-source>
+<network>
+
+
+<!--list of global events-->
+<event size="1" name="tick"/>
+<event size="0" name="reset"/>
+
+
+<!--list of constants-->
+
+
+<!--show keywords state-->
+<keywords flag="true"/>
+
+
+<!--node dummynode-1-->
+<node nodeId="2" name="dummynode-1">var clock = 0
+var vec[3] = [1,2,3]
+
+onevent timer
+clock += 1
+if clock%150 == 0 then
+        emit tick([clock/150])
+end
+
+onevent reset
+clock = 0</node>
+
+
+</network>

--- a/switches/http/dummynode-1.aesl
+++ b/switches/http/dummynode-1.aesl
@@ -1,0 +1,20 @@
+<!DOCTYPE aesl-source>
+<network>
+
+
+<!--list of global events-->
+
+
+<!--list of constants-->
+
+
+<!--show keywords state-->
+<keywords flag="true"/>
+
+
+<!--node dummynode-0-->
+<node nodeId="1" name="dummynode-1">var tick = 0
+var vec[3] = [1,2,3]</node>
+
+
+</network>

--- a/switches/http/http.cpp
+++ b/switches/http/http.cpp
@@ -1,0 +1,1263 @@
+
+/*
+ asebahttp - a switch to bridge Aseba to HTTP
+ 2014-12-01 David James Sherman <david dot sherman at inria dot fr>
+ 
+ Provide a simple REST interface with introspection for Aseba devices.
+ 
+    GET  /nodes                                 - JSON list of all known nodes
+    GET  /nodes/:NODENAME                       - JSON attributes for :NODENAME
+    PUT  /nodes/:NODENAME                       - write new Aesl program (file= in multipart/form-data)
+    GET  /nodes/:NODENAME/:VARIABLE             - retrieve JSON value for :VARIABLE
+    POST /nodes/:NODENAME/:VARIABLE             - send new values(s) for :VARIABLE
+    POST /nodes/:NODENAME/:EVENT                - call an event :EVENT
+    GET  /events[/:EVENT]*                      - create SSE stream for all known nodes
+    GET  /nodes/:NODENAME/events[/:EVENT]*      - create SSE stream for :NODENAME
+ 
+ Typical use: asebahttp --port 3000 --aesl vmcode.aesl ser:name=Thymio-II & After vmcode.aesl is compiled 
+ and uploaded, check with curl http://127.0.0.1:3000/nodes/thymio-II
+ 
+ Substitute appropriate values for :NODENAME, :VARIABLE, :EVENT and their parameters. In most cases, 
+ :NODENAME is thymio-II. For example.
+ 
+   - curl http://localhost:3000/nodes/thymio-II/motor.left.target/100 sets the speed of the left motor
+   - curl http://nodes/thymio-II/sound_system/4/10 might record sound number 4 for 10 seconds, if such an event were defined in AESL.
+ 
+ Variables and events are learned from the node description and parsed from AESL source when provided. 
+ Server-side event (SSE) streams are updated as events arrive. If a variable and an event have the same 
+ name, it is the EVENT that is called. On a local machine the server can handle 600 requests/sec with 10 
+ concurrent connections, more (up to 2.5 times more) if the requests are pipelined as is the HTTP/1.1 default.
+ 
+ Start an 'asebadummynode 0' and run 'make test' to execute some basic unit tests. Example Node-RED flows 
+ can be found in ../../examples/http/node-red.
+ 
+ DONE (mostly):
+    - Dashel connection to one Thymio-II and round-robin scheduling between Aseba and HTTP connections
+    - read Aesl program at launch, upload to Thymio-II, and record interface for introspection
+    - GET /nodes, GET /nodes/:NODENAME with introspection
+    - POST /nodes/:NODENAME/:VARIABLE (sloppily allows GET /nodes/:NODENAME/:VARIABLE/:VALUE[/:VALUE]*)
+    - POST /nodes/:NODENAME/:EVENT (sloppily allows GET /nodes/:NODENAME/:EVENT[/:VALUE]*)
+    - form processing for updates and events (POST /.../:VARIABLE) and (POST /.../:EVENT)
+    - handle asynchronous variable reporting (GET /nodes/:NODENAME/:VARIABLE)
+    - JSON format for variable reporting (GET /nodes/:NODENAME/:VARIABLE)
+    - implement SSE streams and event filtering (GET /events) and (GET /nodes/:NODENAME/events)
+    - Aesl program bytecode upload (PUT /nodes/:NODENAME)
+      use curl --data-ascii "file=$(cat vmcode.aesl)" -X PUT http://127.0.0.1:3000/nodes/thymio-II
+    - accept JSON payload rather than HTML form for updates and events (POST /.../:VARIABLE) and (POST /.../:EVENT)
+ 
+ TODO:
+    - handle more than just one Thymio-II node
+    - gracefully shut down TCP/IP connections (half-close, wait, close)
+ 
+ This code borrows from the rest of Aseba, especially switches/medulla and examples/clients/cpp-shell,
+ which bear the copyright and LGPL 3 licensing notice below.
+ 
+ */
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2012:
+ Stephane Magnenat <stephane at magnenat dot net>
+ (http://stephane.magnenat.net)
+ and other contributors, see authors.txt for details
+	
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+	
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <set>
+#include <valarray>
+#include <vector>
+#include <iterator>
+#include "http.h"
+#include "../../common/consts.h"
+#include "../../common/types.h"
+#include "../../common/utils/utils.h"
+#include "../../transport/dashel_plugins/dashel-plugins.h"
+
+#if defined(_WIN32) && defined(__MINGW32__)
+/* This is a workaround for MinGW32, see libxml/xmlexports.h */
+#define IN_LIBXML
+#endif
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
+#if DASHEL_VERSION_INT < 10003
+#	error "You need at least Dashel version 1.0.3 to compile Http"
+#endif // DAHSEL_VERSION_INT
+
+//== Some utility functions and diverse hacks ==============================================
+
+// close the stream, this is a hack because Dashel lacks a proper shutdown mechanism
+void shutdownStream(Dashel::Stream* stream)
+{
+    stream->fail(Dashel::DashelException::Unknown, 0, "Request handling complete");
+}
+
+std::string readLine(Dashel::Stream* stream)
+{
+    char c;
+    std::string line;
+    do
+    {
+        stream->read(&c, 1);
+        line += c;
+    }
+    while (c != '\n');
+    return line;
+}
+
+
+//== Main event ============================================================================
+
+namespace Aseba
+{
+    using namespace std;
+    using namespace Dashel;
+    
+    /** \addtogroup http */
+    /*@{*/
+    
+    
+    //-- Subclassing Dashel::Hub -----------------------------------------------------------
+    
+    
+    HttpInterface::HttpInterface(const std::string& asebaTarget, const std::string& http_port, const int iterations) :
+    Hub(false),  // don't resolve hostnames for incoming connections (there are a lot of them!)
+    asebaStream(0),
+    httpStream(0),
+    nodeId(0),
+    nodeDescriptionComplete(false),
+    verbose(false),
+    iterations(iterations)
+    // created empty: pendingResponses, pendingVariables, eventSubscriptions, httpRequests, streamsToShutdown
+    {
+        // connect to the Aseba target
+        std::cout << "HttpInterface connect asebaTarget " << asebaTarget << "\n";
+        connect(asebaTarget); // triggers connectionCreated, which assigns asebaStream
+        
+        // request a description for aseba target
+        broadcastGetDescription();
+        
+        // listen for incoming HTTP requests
+        httpStream = connect("tcpin:port=" + http_port);
+    }
+    
+    void HttpInterface::broadcastGetDescription()
+    {
+        GetDescription getDescription;
+        getDescription.serialize(asebaStream);
+        asebaStream->flush();
+    }
+    
+    void HttpInterface::run()
+    {
+        do
+        {
+            sendAvailableResponses();
+            step(2);
+            if (verbose && streamsToShutdown.size() > 0)
+            {
+                cerr << "HttpInterface::run "<< streamsToShutdown.size() <<" streams to shut down";
+                for (std::set<Dashel::Stream*>::iterator si = streamsToShutdown.begin(); si != streamsToShutdown.end(); si++)
+                    cerr << " " << *si;
+                cerr << endl;
+            }
+            if (!streamsToShutdown.empty())
+            {
+                std::set<Dashel::Stream*>::iterator i = streamsToShutdown.begin();
+                Dashel::Stream* stream_to_shutdown = *i;
+                streamsToShutdown.erase(*i); // invalidates iterator
+                try
+                {
+                    if (verbose)
+                        cerr << stream_to_shutdown << " shutting down stream" << endl;
+                    shutdownStream(stream_to_shutdown);
+                }
+                catch(Dashel::DashelException& e)
+                { }
+            }
+        } while (iterations-- != 0 and asebaStream != 0);
+        for (StreamResponseQueueMap::iterator i = pendingResponses.begin(); i != pendingResponses.end(); i++)
+            unscheduleAllResponses(i->first);
+    }
+    
+    void HttpInterface::connectionCreated(Dashel::Stream *stream)
+    {
+        if (!asebaStream)
+        {
+            // this is the connection to the Thymio-II
+            std::cout << "Incoming Aseba connection from " << stream->getTargetName() << endl;
+            asebaStream = stream;
+        }
+        else
+        {
+            // this is an incoming HTTP connection
+            if (verbose)
+                cerr << stream << " Connection created to " << stream->getTargetName() << endl;
+            
+            assert( pendingResponses[stream].empty() );
+        }
+    }
+    
+    void HttpInterface::connectionClosed(Stream * stream, bool abnormal)
+    {
+        if (stream == asebaStream)
+        {
+            // first close all HTTP connections
+            for (StreamResponseQueueMap::iterator m = pendingResponses.begin(); m != pendingResponses.end(); m++)
+                closeStream(m->first);
+            // then stop the hub
+            asebaStream = 0;
+            if (verbose)
+                cerr << "Connection closed to Aseba target" << endl;
+            stop();
+        }
+        else
+        {
+            if (verbose)
+                cerr << stream << " Connection closed to " << stream->getTargetName() << endl;
+            unscheduleAllResponses(stream);
+            pendingResponses.erase(stream);
+            unsigned num = streamsToShutdown.erase(stream);
+            if (verbose)
+                cerr << stream << " Connection closed, removed " << num << " pending shutdowns" << endl;
+        }
+    }
+    
+    void HttpInterface::nodeDescriptionReceived(unsigned nodeId)
+    {
+        if (verbose)
+            wcerr << this << L"Received description for " << getNodeName(nodeId) << endl;
+        if (!nodeId) return;
+        this->nodeId = nodeId;
+        nodeDescriptionComplete = true;
+    }
+    
+    bool HttpInterface::descriptionReceived()
+    {
+        if (verbose)
+            wcerr << this << L"check descriptionReceived: nodeId = " << nodeId << L", flag = " << nodeDescriptionComplete << L", name=" << getNodeName(nodeId) << endl;
+        //return (nodeId > 0);
+        return nodeDescriptionComplete;
+    }
+    
+    void HttpInterface::incomingData(Stream *stream)
+    {
+        if (stream == asebaStream) {
+            // incoming Aseba message
+            if (verbose)
+                cerr << "incoming for asebaStream " << stream << endl;
+            
+            Message *message(Message::receive(stream));
+            
+            // pass message to description manager, which builds
+            // the node descriptions in background
+            DescriptionsManager::processMessage(message);
+            
+            // if variables, check for pending requests
+            const Variables *variables(dynamic_cast<Variables *>(message));
+            if (variables)
+                incomingVariables(variables);
+            
+            // if event, retransmit it on an HTTP SSE channel if one exists
+            const UserMessage *userMsg(dynamic_cast<UserMessage *>(message));
+            if (userMsg)
+                incomingUserMsg(userMsg);
+            
+            delete message;
+        }
+        else
+        {
+            // incoming HTTP request
+            if (verbose)
+                cerr << "incoming for HTTP stream " << stream << endl;
+            HttpRequest* req = new HttpRequest; // [promise] we will eventually delete req in sendAvailableResponses, unscheduleResponse, or stream shutdown
+            if ( ! req->initialize(stream))
+            {   // protocol failure, shut down connection
+                stream->write("HTTP/1.1 400 Bad request\r\n");
+                stream->fail(DashelException::Unknown, 0, "400 Bad request");
+                unscheduleAllResponses(stream);
+                delete req; // not yet in queue, so delete it here [promise]
+                return;
+            }
+            
+            if (verbose)
+            {
+                cerr << stream << " Request " << req->method.c_str() << " " << req->uri.c_str() << " [ ";
+                for (unsigned int i = 0; i < req->tokens.size(); ++i)
+                    cerr << req->tokens[i] << " ";
+                cerr << "] " << req->protocol_version << " new req " << req << endl;
+            }
+            // continue with incomingData
+            scheduleResponse(stream, req);
+            req->incomingData(); // read request all at once
+            if (req->ready)
+                routeRequest(req);
+            // run response queues immediately to save time
+            sendAvailableResponses();
+        }
+    }
+    
+    // Incoming Variables
+    void HttpInterface::incomingVariables(const Variables *variables)
+    {
+        // first, build result string from message
+        std::stringstream result;
+        result << "[";
+        for (size_t i = 0; i < variables->variables.size(); ++i)
+            result << (i ? "," : "") << variables->variables[i];
+        result << "]";
+        string result_str = result.str();
+        
+        VariableAddress address = std::make_pair(variables->source,variables->start);
+        ResponseSet *pending = &pendingVariables[address];
+        
+        if (verbose)
+        {
+            cerr << "incomingVariables var (" << variables->source << "," << variables->start << ") = "
+                 << result_str << endl << "\tupdates " << pending->size() << " pending";
+            for (ResponseSet::iterator i = pending->begin(); i != pending->end(); i++)
+                cerr << " " << *i;
+            cerr << endl;
+        }
+        
+        for (ResponseSet::iterator i = pending->begin(); i != pending->end(); )
+        {
+            // i points to an HttpRequest* that is waiting for this variable value
+            if (verbose)
+                cerr << *i << " updating response var (" << variables->source << "," << variables->start << ")" << endl;
+            finishResponse(*i, 200, result_str);
+            pending->erase(i++);
+        }
+        if (verbose)
+        {
+            cerr << "\tcheck " << pendingVariables[address].size() << " pending";
+            for (ResponseSet::iterator i =
+                 pendingVariables[address].begin(); i != pendingVariables[address].end(); i++)
+                cerr << " " << *i;
+            cerr << endl;
+        }
+        sendAvailableResponses();
+    }
+    
+    // Incoming User Messages
+    void HttpInterface::incomingUserMsg(const UserMessage *userMsg)
+    {
+        if (verbose)
+            cerr << "incomingUserMsg msg ("<< userMsg->type <<","<< &userMsg->data <<")" << endl;
+        
+        // skip if event not known (yet, aesl probably not loaded)
+        try { commonDefinitions.events.at(userMsg->type); }
+        catch (const std::out_of_range& oor) { return; }
+        
+        if (commonDefinitions.events[userMsg->type].name.find(L"R_state")==0)
+        {
+            // update variables
+        }
+        if (eventSubscriptions.size() > 0)
+        {
+            // set up SSE message
+            std::stringstream reply;
+            string event_name = WStringToUTF8(commonDefinitions.events[userMsg->type].name);
+            reply << "data: " << event_name;
+            for (size_t i = 0; i < userMsg->data.size(); ++i)
+                reply << " " << userMsg->data[i];
+            reply << "\r\n\r\n";
+            
+            // In the HTTP world we set up a stream of Server-Sent Events for this.
+            // Note that event name is in commonDefinitions.events[userMsg->type].name
+            
+            for (StreamEventSubscriptionMap::iterator subscriber = eventSubscriptions.begin();
+                 subscriber != eventSubscriptions.end(); ++subscriber)
+            {
+                if (subscriber->second.count("*") >= 1 || subscriber->second.count(event_name) >= 1)
+                {
+                    appendResponse(subscriber->first, 200, true, reply.str().c_str());
+                }
+            }
+        }
+    }
+    
+    //-- Routing for HTTP requests ---------------------------------------------------------
+    
+    void HttpInterface::routeRequest(HttpRequest* req)
+    {
+        // route based on uri prefix
+        if (req->tokens[0].find("nodes")==0)
+        {
+            req->tokens.erase(req->tokens.begin(),req->tokens.begin()+1);
+            
+            if (req->tokens.size() <= 1)
+            {   // one named node
+                if (req->method.find("PUT")==0)
+                    evLoad(req, req->tokens);  // load bytecode for one node
+                else
+                    evNodes(req, req->tokens); // get info for one node
+            }
+            else if (req->tokens.size() >= 2 && req->tokens[1].find("events")==0)
+            {   // subscribe to event stream for this node
+                req->tokens.erase(req->tokens.begin(),req->tokens.begin()+1);
+                evSubscribe(req, req->tokens);
+            }
+            else
+            {   // request for a varibale or an event
+                evVariableOrEvent(req, req->tokens);
+            }
+            return;
+        }
+        if (req->tokens[0].find("events")==0)
+        {   // subscribe to event stream for all nodes
+            return evSubscribe(req, req->tokens);
+        }
+        if (req->tokens[0].find("reset")==0 || req->tokens[0].find("reset_all")==0)
+        {   // reset nodes
+            return evReset(req, req->tokens);
+        }
+        else
+            finishResponse(req, 404, "");
+    }
+    
+    // Handler: Node descriptions
+    
+    void HttpInterface::evNodes(HttpRequest* req, strings& args)
+    {
+        bool do_one_node(args.size() > 0);
+        
+        std::stringstream json;
+        json << (do_one_node ? "" : "[");
+        
+        for (NodesDescriptionsMap::iterator descIt = nodesDescriptions.begin();
+             descIt != nodesDescriptions.end(); ++descIt)
+        {
+            const NodeDescription& description(descIt->second);
+            string nodeName = WStringToUTF8(description.name);
+            
+            json << "{";
+            json << "\"name\":\"" << nodeName << "\",\"protocolVersion\":" << description.protocolVersion;
+            
+            if (do_one_node)
+            {
+                json << ",\"bytecodeSize\":" << description.bytecodeSize;
+                json << ",\"variablesSize\":" <<description.variablesSize;
+                json << ",\"stackSize\":" << description.stackSize;
+                
+                // named variables
+                json << ",\"namedVariables\":{";
+                bool seen_named_variables = false;
+                for (NodeNameVariablesMap::const_iterator n(allVariables.find(nodeName));
+                     n != allVariables.end(); ++n)
+                {
+                    VariablesMap vm = n->second;
+                    for (VariablesMap::iterator i = vm.begin();
+                         i != vm.end(); ++i)
+                    {
+                        json << (i == vm.begin() ? "" : ",") << "\"" << WStringToUTF8(i->first) << "\":" << i->second.second;
+                        seen_named_variables = true;
+                    }
+                }
+                if ( ! seen_named_variables )
+                {
+                    // failsafe: if compiler hasn't found any variables, get them from the node description
+                    for (vector<Aseba::TargetDescription::NamedVariable>::const_iterator i(description.namedVariables.begin());
+                         i != description.namedVariables.end(); ++i)
+                        json << (i == description.namedVariables.begin() ? "" : ",")
+                        << "\"" << WStringToUTF8(i->name) << "\":" << i->size;
+                }
+                json << "}";
+                
+                // local events variables
+                json << ",\"localEvents\":{";
+                for (size_t i = 0; i < description.localEvents.size(); ++i)
+                {
+                    string ev(WStringToUTF8(description.localEvents[i].name));
+                    json << (i == 0 ? "" : ",")
+                    << "\"" << ev << "\":"
+                    << "\"" << WStringToUTF8(description.localEvents[i].description) << "\"";
+                }
+                json << "}";
+                
+                // constants from introspection
+                json << ",\"constants\":{";
+                for (size_t i = 0; i < commonDefinitions.constants.size(); ++i)
+                    json << (i == 0 ? "" : ",")
+                    << "\"" << WStringToUTF8(commonDefinitions.constants[i].name) << "\":"
+                    << commonDefinitions.constants[i].value;
+                json << "}";
+                
+                // events from introspection
+                json << ",\"events\":{";
+                for (size_t i = 0; i < commonDefinitions.events.size(); ++i)
+                    json << (i == 0 ? "" : ",")
+                    << "\"" << WStringToUTF8(commonDefinitions.events[i].name) << "\":"
+                    << commonDefinitions.events[i].value;
+                json << "}";
+            }
+            json << "}";
+        }
+        
+        json <<(do_one_node ? "" : "]");
+        finishResponse(req,200,json.str());
+    }
+    
+    // Handler: Variable get/set or Event call
+    
+    void HttpInterface::evVariableOrEvent(HttpRequest* req, strings& args)
+    {
+        string nodeName(args[0]);
+        size_t eventPos;
+        
+        if ( ! commonDefinitions.events.contains(UTF8ToWString(args[1]), &eventPos))
+        {
+            // this is a variable
+            if (req->method.find("POST") == 0 || args.size() >= 3)
+            {
+                // set variable value
+                strings values;
+                if (args.size() >= 3)
+                    values.assign(args.begin()+1, args.end());
+                else
+                {
+                    // Parse POST form data
+                    values.push_back(args[1]);
+                    parse_json_form(req->content, values);
+                }
+                if (values.size() == 0)
+                {
+                    finishResponse(req, 404, "");
+                    if (verbose)
+                        cerr << req << " evVariableOrEevent 404 can't set variable " << args[0] << ", no values" <<  endl;
+                    return;
+                }
+                sendSetVariable(nodeName, values);
+                finishResponse(req, 200, "");
+                if (verbose)
+                    cerr << req << " evVariableOrEevent 200 set variable " << values[0] <<  endl;
+            }
+            else
+            {
+                // get variable value
+                strings values;
+                values.assign(args.begin()+1, args.begin()+2);
+                
+                unsigned source, start;
+                if ( ! getNodeAndVarPos(nodeName, values[0], source, start))
+                {
+                    finishResponse(req, 404, "");
+                    if (verbose)
+                        cerr << req << " evVariableOrEevent 404 no such variable " << values[0] <<  endl;
+                    return;
+                }
+                
+                sendGetVariables(nodeName, values);
+                pendingVariables[std::make_pair(source,start)].insert(req);
+                
+                if (verbose)
+                    cerr << req << " evVariableOrEevent schedule var " << values[0]
+                    << "(" << source << "," << start << ") add " << req << " to subscribers" <<  endl;
+                return;
+            }
+        }
+        else
+        {
+            // this is an event
+            // arguments are args 1..N
+            strings data;
+            data.push_back(args[1]);
+            if (args.size() >= 3)
+                for (size_t i=2; i<args.size(); ++i)
+                    data.push_back((args[i].c_str()));
+            else if (req->method.find("POST") == 0)
+            {
+                // Parse POST form data
+                parse_json_form(std::string(req->content, req->content.size()), data);
+            }
+            sendEvent(nodeName, data);
+            finishResponse(req, 200, ""); // or perhaps {"return_value":null,"cmd":"sendEvent","name":nodeName}?
+            return;
+        }
+    }
+    
+    // Handler: Subscribe to an event stream
+    
+    void HttpInterface::evSubscribe(HttpRequest* req, strings& args)
+    {
+        // eventSubscriptions[conn] is an unordered set of strings
+        if (args.size() == 1)
+            eventSubscriptions[req].insert("*");
+        else
+            for (strings::iterator i = args.begin()+1; i != args.end(); ++i)
+                eventSubscriptions[req].insert(*i);
+        
+        strings headers;
+        headers.push_back("Content-Type: text/event-stream");
+        headers.push_back("Cache-Control: no-cache");
+        headers.push_back("Connection: keep-alive");
+        addHeaders(req, headers);
+        appendResponse(req,200,true,"");
+        // connection must stay open!
+    }
+    
+    // Handler: Compile and store a program into the node, and remember it for introspection
+    
+    void HttpInterface::evLoad(HttpRequest* req, strings& args)
+    {
+        if (verbose)
+            cerr << "PUT /nodes/" << args[0].c_str() << " trying to load aesl script\n";
+        const char* buffer = req->content.c_str();
+        size_t pos = req->content.find("file=");
+        if (pos != std::string::npos)
+        {
+            aeslLoadMemory(buffer+pos+5, req->content.size()-pos-5);
+            finishResponse(req, 200, "");
+        }
+        else
+            finishResponse(req, 400, "");
+    }
+    
+    // Handler: Reset nodes and rerun
+    
+    void HttpInterface::evReset(HttpRequest* req, strings& args)
+    {
+        for (NodesDescriptionsMap::iterator descIt = nodesDescriptions.begin();
+             descIt != nodesDescriptions.end(); ++descIt)
+        {
+            bool ok;
+            nodeId = getNodeId(descIt->second.name, 0, &ok);
+            if (!ok)
+                continue;
+            string nodeName = WStringToUTF8(descIt->second.name);
+            
+            Reset(nodeId).serialize(asebaStream); // reset node
+            asebaStream->flush();
+            Run(nodeId).serialize(asebaStream);   // re-run node
+            asebaStream->flush();
+            if (nodeName.find("thymio-II") == 0)
+            {
+                strings args;
+                args.push_back("motor.left.target");
+                args.push_back("0");
+                sendSetVariable(nodeName, args);
+                args[0] = "motor.right.target";
+                sendSetVariable(nodeName, args);
+            }
+            size_t eventPos;
+            if (commonDefinitions.events.contains(UTF8ToWString("reset"), &eventPos))
+            {
+                strings data;
+                data.push_back("reset");
+                sendEvent(nodeName,data);
+            }
+            
+            finishResponse(req, 200, "");
+        }
+    }
+    
+    
+    
+    //-- Sending messages on the Aseba bus -------------------------------------------------
+    
+    void HttpInterface::sendEvent(const std::string nodeName, const strings& args)
+    {
+        size_t eventPos;
+        
+        if (commonDefinitions.events.contains(UTF8ToWString(args[0]), &eventPos))
+        {
+            // build event and emit
+            UserMessage::DataVector data;
+            for (size_t i=1; i<args.size(); ++i)
+                data.push_back(atoi(args[i].c_str()));
+            UserMessage userMessage(eventPos, data);
+            userMessage.serialize(asebaStream);
+            asebaStream->flush();
+        }
+        else if (verbose)
+            cerr << "sendEvent " << nodeName << ": no event " << args[0] << endl;
+    }
+    
+    std::pair<unsigned,unsigned> HttpInterface::sendGetVariables(const std::string nodeName, const strings& args)
+    {
+        unsigned nodePos, varPos;
+        for (strings::const_iterator it(args.begin()); it != args.end(); ++it)
+        {
+            // get node id, variable position and length
+            if (verbose)
+                cerr << "getVariables " << nodeName << " " << *it;
+            const bool exists(getNodeAndVarPos(nodeName, *it, nodePos, varPos));
+            if (!exists)
+                continue;
+            
+            VariablesMap vm = allVariables[nodeName];
+            const unsigned length(vm[UTF8ToWString(*it)].second);
+            
+            if (verbose)
+                cerr << " (" << nodePos << "," << varPos << "):" << length << "\n";
+            // send the message
+            GetVariables getVariables(nodePos, varPos, length);
+            getVariables.serialize(asebaStream);
+        }
+        asebaStream->flush();
+        return std::pair<unsigned,unsigned>(nodePos,varPos); // just last one
+    }
+    
+    void HttpInterface::sendSetVariable(const std::string nodeName, const strings& args)
+    {
+        // get node id, variable position and length
+        if (verbose)
+            cerr << "setVariables " << nodeName << " " << args[0];
+        unsigned nodePos, varPos;
+        const bool exists(getNodeAndVarPos(nodeName, args[0], nodePos, varPos));
+        if (!exists)
+            return;
+        
+        if (verbose)
+            cerr << " (" << nodePos << "," << varPos << "):" << args.size()-1 << endl;
+        // send the message
+        SetVariables::VariablesVector data;
+        for (size_t i=1; i<args.size(); ++i)
+            data.push_back(atoi(args[i].c_str()));
+        SetVariables setVariables(nodePos, varPos, data);
+        setVariables.serialize(asebaStream);
+        asebaStream->flush();
+    }
+    
+    // Utility: find variable address
+    bool HttpInterface::getNodeAndVarPos(const string& nodeName, const string& variableName,
+                                         unsigned& nodeId, unsigned& pos)
+    {
+        // make sure the node exists
+        bool ok;
+        nodeId = getNodeId(UTF8ToWString(nodeName), 0, &ok);
+        if (!ok)
+        {
+            if (verbose)
+                wcerr << "invalid node name " << UTF8ToWString(nodeName) << endl;
+            return false;
+        }
+        pos = unsigned(-1);
+        
+        // check whether variable is known from a compilation, if so, get position
+        const NodeNameVariablesMap::const_iterator allVarMapIt(allVariables.find(nodeName));
+        if (allVarMapIt != allVariables.end())
+        {
+            const VariablesMap& varMap(allVarMapIt->second);
+            const VariablesMap::const_iterator varIt(varMap.find(UTF8ToWString(variableName)));
+            if (varIt != varMap.end())
+                pos = varIt->second.first;
+        }
+        
+        // if variable is not user-defined, check whether it is provided by this node
+        if (pos == unsigned(-1))
+        {
+            bool ok;
+            pos = getVariablePos(nodeId, UTF8ToWString(variableName), &ok);
+            if (!ok)
+            {
+                if (verbose)
+                    wcerr << "no variable " << UTF8ToWString(variableName) << " in node " << UTF8ToWString(nodeName);
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    // Utility: request update of all variables, used for variable caching
+    void HttpInterface::updateVariables(const std::string nodeName)
+    {
+        strings all_variables;
+        for(VariablesMap::iterator it = allVariables[nodeName].begin(); it != allVariables[nodeName].end(); ++it)
+            all_variables.push_back(WStringToUTF8(it->first));
+        sendGetVariables(nodeName, all_variables);
+    }
+    
+    // Utility: extract argument values from JSON request body
+    void HttpInterface::parse_json_form(std::string content, strings& values)
+    {
+        std::string buffer = content;
+        buffer.erase(std::remove_if(buffer.begin(), buffer.end(), ::isspace), buffer.end());
+        std::stringstream ss(buffer);
+        
+        if (ss.get() == '[')
+        {
+            int i;
+            while (ss >> i)
+            {
+                // values.push_back(std::to_string(short(i)));
+                std::stringstream valss;
+                valss << short(i);
+                values.push_back(valss.str());
+                if (ss.peek() == ']')
+                    break;
+                else if (ss.peek() == ',')
+                    ss.ignore();
+            }
+            if (ss.get() != ']')
+                values.erase(values.begin(),values.end());
+        }
+        
+        return;
+    }
+    
+    
+    // Load Aesl file from file
+    void HttpInterface::aeslLoadFile(const std::string& filename)
+    {
+        // local file or URL
+        xmlDoc *doc(xmlReadFile(filename.c_str(), NULL, 0));
+        if (!doc)
+            wcerr << "cannot read aesl script XML from file " << UTF8ToWString(filename) << endl;
+        else
+        {
+            aeslLoad(doc);
+            //if (verbose)
+            cerr << "Loaded aesl script from " << filename.c_str() << "\n";
+        }
+        xmlFreeDoc(doc);
+        xmlCleanupParser();
+    }
+    
+    // Load Aesl file from memory
+    void HttpInterface::aeslLoadMemory(const char * buffer, const int size)
+    {
+        // open document
+        xmlDoc *doc(xmlReadMemory(buffer, size, "vmcode.aesl", NULL, 0));
+        if (!doc)
+            wcerr << "cannot read XML from memory " << buffer << endl;
+        else
+        {
+            aeslLoad(doc);
+            //if (verbose)
+            cerr << "Loaded aesl script in-memory buffer " << buffer << "\n";
+        }
+        xmlFreeDoc(doc);
+        xmlCleanupParser();
+    }
+    
+    // Parse Aesl program using XPath
+    void HttpInterface::aeslLoad(xmlDoc* doc)
+    {
+        // clear existing data
+        commonDefinitions.events.clear();
+        commonDefinitions.constants.clear();
+        allVariables.clear();
+        
+        // load new data
+        int noNodeCount(0);
+        bool wasError(false);
+        
+        xmlXPathContextPtr context = xmlXPathNewContext(doc);
+        xmlXPathObjectPtr obj;
+        
+        // 1. Path network/event
+        if ((obj = xmlXPathEvalExpression(BAD_CAST"/network/event", context)))
+        {
+            xmlNodeSetPtr nodeset = obj->nodesetval;
+            for(int i = 0; i < (nodeset ? nodeset->nodeNr : 0); ++i)
+            {
+                xmlChar *name  (xmlGetProp(nodeset->nodeTab[i], BAD_CAST("name")));
+                xmlChar *size  (xmlGetProp(nodeset->nodeTab[i], BAD_CAST("size")));
+                if (name && size)
+                {
+                    int eventSize = atoi((const char *)size);
+                    if (eventSize > ASEBA_MAX_EVENT_ARG_SIZE)
+                    {
+                        wcerr << "Event " << name << " has a length " << eventSize << " larger than maximum"
+                              <<  ASEBA_MAX_EVENT_ARG_SIZE << endl;
+                        wasError = true;
+                        break;
+                    }
+                    else
+                        commonDefinitions.events.push_back(NamedValue(UTF8ToWString((const char *)name), eventSize));
+                }
+                xmlFree(name);
+                xmlFree(size);
+            }
+            xmlXPathFreeObject(obj); // also frees nodeset
+        }
+        // 2. Path network/constant
+        if ((obj = xmlXPathEvalExpression(BAD_CAST"/network/constant", context)))
+        {
+            xmlNodeSetPtr nodeset = obj->nodesetval;
+            for(int i = 0; i < (nodeset ? nodeset->nodeNr : 0); ++i)
+            {
+                xmlChar *name  (xmlGetProp(nodeset->nodeTab[i], BAD_CAST("name")));
+                xmlChar *value (xmlGetProp(nodeset->nodeTab[i], BAD_CAST("value")));
+                if (name && value)
+                    commonDefinitions.constants.push_back(NamedValue(UTF8ToWString((const char *)name),
+                                                                     atoi((const char *)value)));
+                xmlFree(name);  // nop if name is NULL
+                xmlFree(value); // nop if value is NULL
+            }
+            xmlXPathFreeObject(obj); // also frees nodeset
+        }
+        // 3. Path network/keywords
+        if ((obj = xmlXPathEvalExpression(BAD_CAST"/network/keywords", context)))
+        {
+            xmlNodeSetPtr nodeset = obj->nodesetval;
+            for(int i = 0; i < (nodeset ? nodeset->nodeNr : 0); ++i)
+            {
+                xmlChar *flag  (xmlGetProp(nodeset->nodeTab[i], BAD_CAST("flag")));
+                // do nothing because compiler doesn't pay attention to keywords
+                xmlFree(flag);
+            }
+            xmlXPathFreeObject(obj); // also frees nodeset
+        }
+        // 4. Path network/node
+        if ((obj = xmlXPathEvalExpression(BAD_CAST"/network/node", context)))
+        {
+            xmlNodeSetPtr nodeset = obj->nodesetval;
+            for(int i = 0; i < (nodeset ? nodeset->nodeNr : 0); ++i)
+            {
+                xmlChar *name     (xmlGetProp(nodeset->nodeTab[i], BAD_CAST("name")));
+                xmlChar *storedId (xmlGetProp(nodeset->nodeTab[i], BAD_CAST("nodeId")));
+                xmlChar *text     (xmlNodeGetContent(nodeset->nodeTab[i]));
+                
+                if (!name)
+                    wcerr << "missing \"name\" attribute in \"node\" entry" << endl;
+                else if (!text)
+                    wcerr << "missing text in \"node\" entry" << endl;
+                else
+                {
+                    const string _name((const char *)name);
+                    // get the identifier of the node and compile the code
+                    unsigned preferedId = storedId ? unsigned(atoi((char*)storedId)) : 0;
+                    bool ok;
+                    unsigned nodeId(getNodeId(UTF8ToWString(_name), preferedId, &ok));
+                    if (ok)
+                        wasError = !compileAndSendCode(UTF8ToWString((const char *)text), nodeId, _name);
+                    else
+                        noNodeCount++;
+                }
+                // free attribute and content
+                xmlFree(name);     // nop if name is NULL
+                xmlFree(storedId); // nop if name is NULL
+                xmlFree(text);     // nop if text is NULL
+            }
+            xmlXPathFreeObject(obj); // also frees nodeset
+        }
+        
+        // release memory
+        xmlXPathFreeContext(context);
+        
+        // check if there was an error
+        if (wasError)
+        {
+            wcerr << "There was an error while loading script " << endl;
+            commonDefinitions.events.clear();
+            commonDefinitions.constants.clear();
+            allVariables.clear();
+        }
+        
+        // check if there was some matching problem
+        if (noNodeCount)
+        {
+            wcerr << noNodeCount << " scripts have no corresponding nodes in the current network and have not been loaded." << endl;
+        }
+    }
+    
+    // Upload bytecode to node
+    bool HttpInterface::compileAndSendCode(const wstring& source, unsigned nodeId, const string& nodeName)
+    {
+        // compile code
+        std::wistringstream is(source);
+        Error error;
+        BytecodeVector bytecode;
+        unsigned allocatedVariablesCount;
+        
+        Compiler compiler;
+        compiler.setTargetDescription(getDescription(nodeId));
+        compiler.setCommonDefinitions(&commonDefinitions);
+        bool result = compiler.compile(is, bytecode, allocatedVariablesCount, error);
+        
+        if (result)
+        {
+            // send bytecode
+            sendBytecode(asebaStream, nodeId, std::vector<uint16>(bytecode.begin(), bytecode.end()));
+            // run node
+            Run msg(nodeId);
+            msg.serialize(asebaStream);
+            asebaStream->flush();
+            // retrieve user-defined variables for use in get/set
+            allVariables[nodeName] = *compiler.getVariablesMap();
+            return true;
+        }
+        else
+        {
+            wcerr << "compilation for node " << UTF8ToWString(nodeName) << " failed: " << error.toWString() << endl;
+            return false;
+        }
+    }
+    
+    // Manipulate response queues
+    void HttpInterface::scheduleResponse(Dashel::Stream* stream, HttpRequest* req)
+    {
+        pendingResponses[stream].push_back(req);
+    }
+    
+    void HttpInterface::unscheduleResponse(Dashel::Stream* stream, HttpRequest* req)
+    {
+        for (ResponseQueue::iterator i = pendingResponses[stream].begin();
+             i != pendingResponses[stream].end(); ++i)
+            if (*i == req)
+            {
+                delete req; // [promise]
+                pendingResponses[stream].erase(i);
+                break;
+            }
+    }
+    
+    void HttpInterface::unscheduleAllResponses(Dashel::Stream* stream)
+    {
+        while(!pendingResponses[stream].empty())
+        {
+            eventSubscriptions.erase(pendingResponses[stream].front());
+            delete pendingResponses[stream].front(); // [promise]
+            pendingResponses[stream].pop_front();
+        }
+    }
+    
+    void HttpInterface::addHeaders(HttpRequest* req, strings& outheaders)
+    {
+        req->outheaders = outheaders;
+    }
+    
+    void HttpInterface::finishResponse(HttpRequest* req, unsigned status, std::string result)
+    {
+        req->result = result;
+        req->status = status;
+        req->more = false;
+        if (verbose)
+            cerr << req << " finishResponse " << status << " <" << result << ">" << endl;
+    }
+    
+    void HttpInterface::appendResponse(HttpRequest* req, unsigned status, const bool& keep_open, std::string result)
+    {
+        req->status = status;
+        req->result += result;
+        req->more = keep_open;
+        if (verbose)
+            cerr << req << " appendResponse " << req->status << " <" << req->result.substr(0,7) << "...>" <<(keep_open?", keep open":"")<< endl;
+    }
+    
+    void HttpInterface::sendAvailableResponses()
+    {
+        // scan through all streams; use while to post-increment when we remove a stream
+        for (StreamResponseQueueMap::iterator m = pendingResponses.begin();
+             m != pendingResponses.end(); m++)
+        {
+            if (verbose)
+            {
+                cerr << m->first << " sendAvailableResponses " << m->second.size() << " in queue";
+                for (ResponseQueue::iterator qi = m->second.begin(); qi != m->second.end(); qi++)
+                    cerr << " " << *qi;
+                cerr << endl;
+            }
+            bool close_this_stream = false;
+            ResponseQueue* q = &(m->second);
+            
+            // scan through queue for this stream
+            q->begin();
+            while (! q->empty() && q->front()->status != 0)
+            {
+                HttpRequest* req = q->front();
+                req->sendResponse();
+                if ( req->more )
+                    break; // keep this request open
+                
+                if (req->headers["Connection"].find("close")==0 ||
+                    (req->protocol_version == "HTTP/1.0" && !(req->headers["Connection"].find("keep-alive")==0)) )
+                {
+                    // delete all requests, including this one, and remove them from queue
+                    unscheduleAllResponses(req->stream);
+                    close_this_stream = true;
+                }
+                else
+                {
+                    // just this request is finished, delete and remove from queue
+                    delete req; // [promise]
+                    q->pop_front();
+                }
+            }
+            if (verbose)
+                cerr << m->first << " available responses sent, now " << m->second.size() << " in queue" << endl;
+            
+            if (close_this_stream)
+                streamsToShutdown.insert(m->first);
+        }
+    }
+    //== end of class HttpInterface ============================================================
+    
+    
+    HttpRequest::HttpRequest():
+    verbose(false)
+    {};
+    
+    bool HttpRequest::initialize( Dashel::Stream *_stream)
+    {
+        string start_line = readLine(_stream);
+        return initialize(start_line, _stream);
+    }
+    
+    bool HttpRequest::initialize( std::string const& start_line, Dashel::Stream *_stream)
+    {
+        strings parts = split<string>(start_line, " ");
+        if (parts.size() == 3
+            && (parts[0].find("GET",0)==0 || parts[0].find("PUT",0)==0 || parts[0].find("POST",0)==0)
+            && (parts[2].find("HTTP/1.1\r\n",0)==0 || parts[2].find("HTTP/1.0\r\n",0)==0) )
+        {
+            // valid start-line, parse uri
+            return initialize(parts[0], parts[1], parts[2].substr(0,8), _stream);
+        }
+        else
+            return false;
+    }
+    
+    bool HttpRequest::initialize(std::string const& _method,
+                                 std::string const& _uri,
+                                 std::string const& _protocol_version,
+                                 Dashel::Stream *_stream)
+    {
+        tokens.clear();  // parsed URI
+        headers.clear(); // incoming headers
+        content.clear(); // incoming payload
+        ready = false;
+        status = 0;      // outging status
+        result.clear();  // outgoing payload
+        outheaders.clear();  // outgoing payload
+        more = false;
+        headers_done = false;
+        status_sent = false;
+        
+        method = std::string(_method);
+        uri = std::string(_uri);
+        protocol_version = std::string(_protocol_version);
+        stream = _stream;
+        
+        // Also allow %2F as URL part delimiter (see Scratch v430)
+        std::string::size_type n = 0;
+        while ( (n=uri.find("%2F",n)) != std::string::npos)
+            uri.replace(n,3,"/"), n += 1;
+        
+        tokens = split<string>(uri, "/");
+        if (tokens[0].size() == 0)
+            tokens.erase(tokens.begin(),tokens.begin()+1);
+        return true;
+    }
+    
+    void HttpRequest::incomingData()
+    {
+        // for now, snarf complete request from stream
+        while (! headers_done)
+        {
+            const string header_field(readLine(stream));
+            int term = header_field.find("\r\n",0);
+            if (term != 0)
+            {
+                //                // LLVM regexp search is incredibly slow
+                //                std::smatch field;
+                //                std::regex e ("([-A-Za-z0-9_]+): (.*)\r\n");
+                //                std::regex_match (header_field,field,e);
+                //                if (field.size() == 3)
+                //                    headers[field[1]] = field[2];
+                if (header_field.find("Content-Length: ",0,16)==0)
+                    headers["Content-Length"] = header_field.substr(16,term-16);
+                else if (header_field.find("Connection: ",0,12)==0)
+                    headers["Connection"] = header_field.substr(12,term-12);
+            }
+            else
+                headers_done = true;
+        }
+        if (verbose)
+        {
+            cerr << stream << " Headers complete; (" << headers.size() << " headers)";
+            for (std::map<std::string,std::string>::iterator i = headers.begin(); i != headers.end(); ++i)
+                cerr << " " << i->first.c_str() << ":" << i->second.c_str();
+            cerr << endl;
+        }
+        int content_length = atoi(headers["Content-Length"].c_str());
+        content_length = (content_length > 40000) ? 40000 : content_length; // truncate at 40000 bytes
+        char* buffer = new char[ content_length ];
+        stream->read(buffer, content_length);
+        content = std::string(buffer,content_length);
+        delete []buffer;
+        ready = true;
+    }
+    
+    void HttpRequest::sendResponse()
+    {
+        if (verbose)
+            cerr << this << " sendResponse, status " << (status_sent?"":"not ") << "already sent, have "
+            << (result.empty()?"no ":"") << "result" << (more?", more":"") << endl;
+        assert( status >= 100 and status <= 599 );
+        if ( ! status_sent )
+            sendStatus();
+        if ( ! result.empty() )
+            sendPayload();
+        stream->flush();
+    }
+    
+    void HttpRequest::sendStatus()
+    {
+        if (verbose)
+            cerr << this << " sendStatus " << status << endl;
+        std::stringstream reply;
+        reply << "HTTP/1.1 " << status << " ";
+        switch (status)
+        {
+            case 200: reply << "OK";                    break;
+            case 201: reply << "Created";               break;
+            case 400: reply << "Bad Request";           break;
+            case 403: reply << "Forbidden";             break;
+            case 408: reply << "Request Timeout";       break;
+            case 500: reply << "Internal Server Error"; break;
+            case 501: reply << "Not Implemented";       break;
+            case 503: reply << "Service Unavailable";   break;
+            case 404:
+            default:  reply << "Not Found";
+        }
+        if (outheaders.size() == 0)
+        {
+            reply << "\r\nContent-Length: " << result.size() << "\r\n";
+            reply << "Content-Type: application/json\r\n"; // NO ";charset=UTF-8" cf. RFC 7159
+            reply << "Access-Control-Allow-Origin: *\r\n";
+            if (headers["Connection"].find("Keep-Alive")==0)
+                reply << "Connection: Keep-Alive\r\n";
+        }
+        else
+        {
+            for (strings::iterator i = outheaders.begin(); i != outheaders.end(); i++)
+                reply << *i << "\r\n";
+        }
+        reply << "\r\n";
+        
+        int reply_len = reply.str().size();
+        char* reply_str = (char*)malloc(reply_len);
+        memcpy(reply_str, reply.str().c_str(), reply_len);
+        stream->write(reply_str, reply_len);
+        free(reply_str);
+        stream->flush();
+        status_sent = true;
+    }
+    
+    void HttpRequest::sendPayload()
+    {
+        if (verbose)
+            cerr << this << " sendPayload " << result.size() << " bytes" << endl;
+        stream->write(result.c_str(), result.size());
+        result = "";
+    }
+    //== end of class HttpInterface ============================================================
+    
+};  //== end of namespace Aseba ================================================================

--- a/switches/http/http.h
+++ b/switches/http/http.h
@@ -1,0 +1,173 @@
+/*
+	Aseba - an event-based framework for distributed robot control
+	Copyright (C) 2007--2012:
+		Stephane Magnenat <stephane at magnenat dot net>
+		(http://stephane.magnenat.net)
+		and other contributors, see authors.txt for details
+	
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, version 3 of the License.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+	
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ASEBA_HTTP
+#define ASEBA_HTTP
+
+#include <stdint.h>
+#include <list>
+#include <queue>
+#include <dashel/dashel.h>
+#include "../../common/msg/msg.h"
+#include "../../common/msg/descriptions-manager.h"
+
+#if defined(_WIN32) && defined(__MINGW32__)
+/* This is a workaround for MinGW32, see libxml/xmlexports.h */
+#define IN_LIBXML
+#endif
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+#include <libxml/xpath.h>
+#include <libxml/xpathInternals.h>
+
+namespace Aseba
+{
+    /**
+     \defgroup http Software router of messages on TCP and HTTP-over-TCP.
+     */
+    /*@{*/
+    
+    class HttpRequest;
+    
+    //! HTTP interface for aseba network
+    class HttpInterface:  public Dashel::Hub, public Aseba::DescriptionsManager
+    {
+    public: 
+        typedef std::vector<std::string>      strings;
+        typedef std::list<HttpRequest*>       ResponseQueue;
+        typedef std::set<HttpRequest*>        ResponseSet;
+        typedef std::pair<unsigned,unsigned>  VariableAddress;
+        typedef std::map<std::string, Aseba::VariablesMap>      NodeNameVariablesMap;
+        typedef std::map<VariableAddress, ResponseSet>          VariableResponseSetMap;
+        typedef std::map<Dashel::Stream*, ResponseQueue>        StreamResponseQueueMap;
+        typedef std::map<HttpRequest*, std::set<std::string> >  StreamEventSubscriptionMap;
+
+    protected:
+        // streams
+        Dashel::Stream* asebaStream;
+        Dashel::Stream* httpStream;
+        StreamResponseQueueMap     pendingResponses;
+        VariableResponseSetMap     pendingVariables;
+        StreamEventSubscriptionMap eventSubscriptions;
+        std::map<Dashel::Stream*, HttpRequest> httpRequests;
+        std::set<Dashel::Stream*>  streamsToShutdown;
+        unsigned nodeId;
+        bool nodeDescriptionComplete;
+        // debug variables
+        bool verbose;
+        int iterations;
+        
+        // Extract definitions from AESL file
+        Aseba::CommonDefinitions commonDefinitions;
+        NodeNameVariablesMap allVariables;
+
+        //variable cache
+        std::map<std::pair<unsigned,unsigned>, std::vector<short> > variable_cache;
+        
+    public:
+        //default values needed for unit testing
+        HttpInterface(const std::string& target="tcp:;port=33333", const std::string& http_port="3000", const int iterations=-1);
+        virtual void run();
+        virtual bool descriptionReceived();
+        virtual void broadcastGetDescription();
+        virtual void evNodes(HttpRequest* req, strings& args);
+        virtual void evVariableOrEvent(HttpRequest* req, strings& args);
+        virtual void evSubscribe(HttpRequest* req, strings& args);
+        virtual void evLoad(HttpRequest* req, strings& args);
+        virtual void evReset(HttpRequest* req, strings& args);
+        virtual void aeslLoadFile(const std::string& filename);
+        virtual void aeslLoadMemory(const char* buffer, const int size);
+        virtual void updateVariables(const std::string nodeName);
+        
+        virtual void scheduleResponse(Dashel::Stream* stream, HttpRequest* req);
+        virtual void addHeaders(HttpRequest* req, strings& headers);
+        virtual void finishResponse(HttpRequest* req, unsigned status, std::string result);
+        virtual void appendResponse(HttpRequest* req, unsigned status, const bool& keep_open, std::string result);
+        virtual void sendAvailableResponses();
+        virtual void unscheduleResponse(Dashel::Stream* stream, HttpRequest* req);
+        virtual void unscheduleAllResponses(Dashel::Stream* stream);
+        
+    protected:
+        /* // reimplemented from parent classes */
+        virtual void connectionCreated(Dashel::Stream* stream);
+        virtual void connectionClosed(Dashel::Stream* stream, bool abnormal);
+        virtual void incomingData(Dashel::Stream* stream);
+        virtual void nodeDescriptionReceived(unsigned nodeId);
+        // specific to http interface
+        virtual void sendEvent(const std::string nodeName, const strings& args);
+        virtual void sendSetVariable(const std::string nodeName, const strings& args);
+        virtual std::pair<unsigned,unsigned> sendGetVariables(const std::string nodeName, const strings& args);
+        virtual bool getNodeAndVarPos(const std::string& nodeName, const std::string& variableName, unsigned& nodeId, unsigned& pos);
+        virtual void aeslLoad(xmlDoc* doc);
+        virtual void incomingVariables(const Variables *variables);
+        virtual void incomingUserMsg(const UserMessage *userMsg);
+        virtual void routeRequest(HttpRequest* req);
+        
+        // helper functions
+        bool getNodeAndVarPos(const std::string& nodeName, const std::string& variableName, unsigned& nodeId, unsigned& pos) const;
+        bool compileAndSendCode(const std::wstring& source, unsigned nodeId, const std::string& nodeName);
+        virtual void parse_json_form(std::string content, strings& values);
+
+    };
+    
+    class HttpRequest
+    {
+    public:
+        typedef std::vector<std::string> strings;
+        std::string method;
+        std::string uri;
+        std::string protocol_version;
+        Dashel::Stream* stream;
+        strings tokens;  // parsed URI
+        std::map<std::string,std::string> headers; // incoming headers
+        std::string content; // incoming payload
+        bool ready; // incoming request is ready
+        unsigned status; // outging status
+        std::string result; // outgoing payload
+        strings outheaders;
+        bool more; // keep connection open for SSE
+    protected:
+        bool headers_done; // flag for header parsing
+        bool status_sent;  // flag for SSE
+        bool verbose;
+        
+    public:
+        HttpRequest();
+        virtual ~HttpRequest() {};
+        virtual bool initialize( Dashel::Stream *stream); //
+        virtual bool initialize( std::string const& start_line, Dashel::Stream *stream); //
+        virtual bool initialize( std::string const& method,  std::string const& uri, std::string const& _protocol_version, Dashel::Stream *stream);
+        virtual void incomingData();
+        virtual void sendResponse();
+        virtual void sendStatus();
+        virtual void sendPayload();
+    };
+
+    class InterruptException : public std::exception
+    {
+    public:
+        InterruptException(int s) : S(s) {}
+        int S;
+    };
+    
+    /*@}*/
+};
+
+#endif

--- a/switches/http/main.cpp
+++ b/switches/http/main.cpp
@@ -1,0 +1,115 @@
+//
+//  main.cpp
+//  
+//
+//  Created by David Sherman on 2014-12-30.
+//
+//
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
+#include "http.h"
+#include "../../common/consts.h"
+#include "../../common/types.h"
+#include "../../common/utils/utils.h"
+#include "../../transport/dashel_plugins/dashel-plugins.h"
+
+//! Show usage
+void dumpHelp(std::ostream &stream, const char *programName)
+{
+    stream << "Aseba http, connects aseba components together and with HTTP, usage:\n";
+    stream << programName << " [options] [additional targets]*\n";
+    stream << "Options:\n";
+    stream << "-v, --verbose   : makes the switch verbose\n";
+    stream << "-d, --dump      : makes the switch dump the content of messages\n";
+    stream << "-p, --port port : listens to incoming connection HTTP on this port\n";
+    stream << "-a, --aesl file : load program definitions from AESL file\n";
+    stream << "-K, --Kiter n   : run I/O loop n thousand times (for profiling)\n";
+    stream << "-h, --help      : shows this help\n";
+    stream << "-V, --version   : shows the version number\n";
+    stream << "Additional targets are any valid Dashel targets." << std::endl;
+    stream << "Report bugs to: david.sherman@inria.fr" << std::endl;
+}
+
+//! Show version
+void dumpVersion(std::ostream &stream)
+{
+    stream << "asebahttp 2015-01-01 David James Sherman <david dot sherman at inria dot fr>" << std::endl;
+    stream << "Aseba version " << ASEBA_VERSION << std::endl;
+    stream << "Aseba protocol " << ASEBA_PROTOCOL_VERSION << std::endl;
+    stream << "Aseba library licence LGPLv3: GNU LGPL version 3 <http://www.gnu.org/licenses/lgpl.html>\n";
+}
+
+
+// Main
+int main(int argc, char *argv[])
+{
+    Dashel::initPlugins();
+    
+    std::string http_port = "3000";
+    std::string aesl_filename;
+    std::string dashel_target;
+    bool verbose = false;
+    bool dump = false;
+    int Kiterations = -1; // set to > 0 to limit run time e.g. for valgrind
+        
+    // process command line
+    int argCounter = 1;
+    while (argCounter < argc)
+    {
+        const char *arg = argv[argCounter++];
+        
+        if ((strcmp(arg, "-v") == 0) || (strcmp(arg, "--verbose") == 0))
+            verbose = true;
+        else if ((strcmp(arg, "-d") == 0) || (strcmp(arg, "--dump") == 0))
+            dump = true;
+        else if ((strcmp(arg, "-h") == 0) || (strcmp(arg, "--help") == 0))
+            dumpHelp(std::cout, argv[0]), exit(1);
+        else if ((strcmp(arg, "-V") == 0) || (strcmp(arg, "--version") == 0))
+            dumpVersion(std::cout), exit(1);
+        else if ((strcmp(arg, "-p") == 0) || (strcmp(arg, "--port") == 0))
+            http_port = argv[argCounter++];
+        else if ((strcmp(arg, "-a") == 0) || (strcmp(arg, "--aesl") == 0))
+            aesl_filename = argv[argCounter++];
+        else if ((strcmp(arg, "-K") == 0) || (strcmp(arg, "--Kiter") == 0))
+            Kiterations = atoi(argv[argCounter++]);
+        else if (strncmp(arg, "-", 1) != 0)
+            dashel_target = arg;
+    }
+    
+    // initialize Dashel plugins
+    Dashel::initPlugins();
+    
+    // create and run bridge, catch Dashel exceptions
+    try
+    {
+        Aseba::HttpInterface* network(new Aseba::HttpInterface(dashel_target, http_port, 1000*Kiterations));
+        
+        for (int i = 0; i < 500; i++)
+            network->step(10); // wait for description, variables, etc
+        if (aesl_filename.size() > 0)
+        {
+            network->aeslLoadFile(aesl_filename);
+        }
+        else
+        {
+            const char* failsafe = "<!DOCTYPE aesl-source><network><keywords flag=\"true\"/><node nodeId=\"1\" name=\"thymio-II\"></node></network>\n";
+            network->aeslLoadMemory(failsafe,strlen(failsafe));
+        }
+        
+        network->run();
+        delete network;
+    }
+    catch(Dashel::DashelException e)
+    {
+        std::cerr << "Unhandled Dashel exception: " << e.what() << std::endl;
+        return 1;
+    }
+    catch (Aseba::InterruptException& e) {
+        std::cerr << " attempting graceful network shutdown" << std::endl;
+    }
+
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,3 +189,17 @@ else (valgrind_FOUND)
 	message("-- valgrind executable not found! Disabling memory leaks tests")
 endif (valgrind_FOUND)
 
+# test asebahttp
+find_package(LibXml2)
+if (LIBXML2_FOUND)
+        include_directories(${LIBXML2_INCLUDE_DIR})
+	include_directories(externals/Catch/include ${COMMON_INCLUDES})
+	add_executable(test-asebahttp test-http.cpp)
+	target_link_libraries(test-asebahttp asebahttphub asebacompiler ${LIBXML2_LIBRARIES} ${ASEBA_CORE_LIBRARIES})
+	configure_file(testdata-HttpRequest.txt ${CMAKE_CURRENT_BINARY_DIR}/testdata-HttpRequest.txt COPYONLY)
+	configure_file(http-valgrind-macosx.supp ${CMAKE_CURRENT_BINARY_DIR}/http-valgrind-macosx.supp COPYONLY)
+	# test HTTP requests and JSON parsing
+	add_test(NAME test-asebahttp COMMAND test-asebahttp)
+else (LIBXML2_FOUND)
+	message("-- libXML2 not found! Disabling HTTP switch tests")
+endif (LIBXML2_FOUND)

--- a/tests/http-valgrind-macosx.supp
+++ b/tests/http-valgrind-macosx.supp
@@ -1,0 +1,495 @@
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_calloc
+   fun:_read_images
+   fun:map_images_nolock
+   fun:map_images
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_ZL12_NXMapRehashP11_NXMapTable
+   fun:NXMapInsert
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_ZL12_NXMapRehashP11_NXMapTable
+   fun:NXMapInsert
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_calloc
+   fun:_read_images
+   fun:map_images_nolock
+   fun:map_images
+   fun:dyld_register_image_state_change_handler
+   fun:_objc_init
+   fun:_os_object_init
+   fun:libdispatch_init
+   fun:libSystem_initializer
+}
+{
+   libobjc_leak_poss
+   Memcheck:Leak
+   match-leak-kinds: possible
+   obj:/usr/lib/libobjc.A.dylib
+}
+{
+   libobjc_leak_def
+   Memcheck:Leak
+   match-leak-kinds: definite
+   obj:/usr/lib/libobjc.A.dylib
+}
+{
+   objc_mutex_malloc
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc_zone_malloc
+   fun:recursive_mutex_init
+   fun:_objc_init
+}
+{
+   objc_hash_ins
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_calloc
+   fun:NXHashInsert
+}
+{
+   objc_map_ins
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:NXMapInsert
+}
+{
+   objc_map_t_new
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:NXCreateMapTableFromZone
+}
+{
+   objc_map_key_copy
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_strdup_internal
+   fun:NXMapKeyCopyingInsert
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_strdup_internal
+   fun:_Z25_objc_allocateFutureClassPKc
+   fun:__CFInitialize
+   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
+   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
+   fun:_ZN4dyld24initializeMainExecutableEv
+   fun:_ZN4dyld5_mainEPK12macho_headermiPPKcS5_S5_Pm
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_ZL17buildProtocolListP13category_listPK15protocol_list_tPS3_
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_read_images
+   fun:map_images_nolock
+   fun:map_images
+   fun:_ZN4dyldL18notifyBatchPartialE17dyld_image_statesbPFPKcS0_jPK15dyld_image_infoE
+   fun:_ZN4dyld36registerImageStateBatchChangeHandlerE17dyld_image_statesPFPKcS0_jPK15dyld_image_infoE
+   fun:dyld_register_image_state_change_handler
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_ZL17buildProtocolListP13category_listPK15protocol_list_tPS3_
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_class_getNonMetaClass
+   fun:lookUpImpOrForward
+   fun:objc_msgSend
+   fun:____CFSearchStringROM_block_invoke
+   fun:_dispatch_client_callout
+   fun:dispatch_once_f
+   fun:__CFStringCreateImmutableFunnel3
+   fun:CFStringCreateWithCString
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc_zone_malloc
+   fun:_CFRuntimeCreateInstance
+   fun:__CFStringCreateImmutableFunnel3
+   fun:CFStringCreateWithCString
+   fun:_CFBundleResourcesInitialize
+   fun:_dispatch_client_callout
+   fun:dispatch_once_f
+   fun:CFBundleGetTypeID
+   fun:__CFInitialize
+   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
+   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_ZL17attachMethodListsP10objc_classPP13method_list_tibbb
+   fun:_ZL21attachCategoryMethodsP10objc_classP13category_listb
+   fun:_ZL16remethodizeClassP10objc_class
+   fun:_read_images
+   fun:map_images_nolock
+   fun:map_images
+   fun:_ZN4dyldL18notifyBatchPartialE17dyld_image_statesbPFPKcS0_jPK15dyld_image_infoE
+   fun:_ZN4dyld36registerImageStateBatchChangeHandlerE17dyld_image_statesPFPKcS0_jPK15dyld_image_infoE
+   fun:dyld_register_image_state_change_handler
+   fun:_objc_init
+   fun:_os_object_init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_calloc
+   fun:_Z25_objc_allocateFutureClassPKc
+   fun:__CFInitialize
+   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
+   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
+   fun:_ZN4dyld24initializeMainExecutableEv
+   fun:_ZN4dyld5_mainEPK12macho_headermiPPKcS5_S5_Pm
+   fun:_ZN13dyldbootstrap5startEPK12macho_headeriPPKclS2_Pm
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:strdup
+   fun:_CFProcessPath
+   fun:__CFInitialize
+   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
+   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
+   fun:_ZN4dyld24initializeMainExecutableEv
+   fun:_ZN4dyld5_mainEPK12macho_headermiPPKcS5_S5_Pm
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_calloc
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_read_images
+   fun:map_images_nolock
+   fun:map_images
+   fun:_ZN4dyldL18notifyBatchPartialE17dyld_image_statesbPFPKcS0_jPK15dyld_image_infoE
+   fun:_ZN4dyld36registerImageStateBatchChangeHandlerE17dyld_image_statesPFPKcS0_jPK15dyld_image_infoE
+   fun:dyld_register_image_state_change_handler
+   fun:_objc_init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_calloc
+   fun:_ZL12realizeClassP10objc_class
+   fun:_class_getNonMetaClass
+   fun:lookUpImpOrForward
+   fun:objc_msgSend
+   fun:____CFSearchStringROM_block_invoke
+   fun:_dispatch_client_callout
+   fun:dispatch_once_f
+   fun:__CFStringCreateImmutableFunnel3
+   fun:CFStringCreateWithCString
+   fun:_CFBundleResourcesInitialize
+   fun:_dispatch_client_callout
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_calloc
+   fun:_Z25_objc_allocateFutureClassPKc
+   fun:__CFInitialize
+   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
+   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
+   fun:_ZN4dyld24initializeMainExecutableEv
+   fun:_ZN4dyld5_mainEPK12macho_headermiPPKcS5_S5_Pm
+   fun:_ZN13dyldbootstrap5startEPK12macho_headeriPPKclS2_Pm
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_ZL17buildPropertyListPK15property_list_tP13category_lista
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_read_images
+   fun:map_images_nolock
+   fun:map_images
+   fun:_ZN4dyldL18notifyBatchPartialE17dyld_image_statesbPFPKcS0_jPK15dyld_image_infoE
+   fun:_ZN4dyld36registerImageStateBatchChangeHandlerE17dyld_image_statesPFPKcS0_jPK15dyld_image_infoE
+   fun:dyld_register_image_state_change_handler
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   fun:class_createInstance
+   fun:_objc_rootAlloc
+   fun:____CFSearchStringROM_block_invoke
+   fun:_dispatch_client_callout
+   fun:dispatch_once_f
+   fun:__CFStringCreateImmutableFunnel3
+   fun:CFStringCreateWithCString
+   fun:_CFBundleResourcesInitialize
+   fun:_dispatch_client_callout
+   fun:dispatch_once_f
+   fun:CFBundleGetTypeID
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc_zone_malloc
+   fun:____CFCharacterSetInitialize_block_invoke
+   fun:_dispatch_client_callout
+   fun:dispatch_once_f
+   fun:__CFInitialize
+   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
+   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
+   fun:_ZN4dyld24initializeMainExecutableEv
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc_zone_malloc
+   fun:_CFRuntimeCreateInstance
+   fun:__CFArrayInit
+   fun:__CFArrayCreate0
+   fun:__CFInitialize
+   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
+   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
+   fun:_ZN4dyld24initializeMainExecutableEv
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_ZL17buildPropertyListPK15property_list_tP13category_lista
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_class_getNonMetaClass
+   fun:lookUpImpOrForward
+   fun:objc_msgSend
+   fun:____CFSearchStringROM_block_invoke
+   fun:_dispatch_client_callout
+   fun:dispatch_once_f
+   fun:__CFStringCreateImmutableFunnel3
+   fun:CFStringCreateWithCString
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_memdup_internal
+   fun:_ZL15fixupMethodListP13method_list_tbb
+   fun:_ZL17attachMethodListsP10objc_classPP13method_list_tibbb
+   fun:_ZL12realizeClassP10objc_class
+   fun:_class_getNonMetaClass
+   fun:lookUpImpOrForward
+   fun:objc_msgSend
+   fun:____CFSearchStringROM_block_invoke
+   fun:_dispatch_client_callout
+   fun:dispatch_once_f
+   fun:__CFStringCreateImmutableFunnel3
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc_zone_malloc
+   fun:__CFGetConverter
+   fun:CFStringEncodingGetConverter
+   fun:CFStringGetSystemEncoding
+   fun:__CFInitialize
+   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
+   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
+   fun:_ZN4dyld24initializeMainExecutableEv
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_memdup_internal
+   fun:_ZL15fixupMethodListP13method_list_tbb
+   fun:_ZL17attachMethodListsP10objc_classPP13method_list_tibbb
+   fun:_ZL21attachCategoryMethodsP10objc_classP13category_listb
+   fun:_ZL16remethodizeClassP10objc_class
+   fun:_read_images
+   fun:map_images_nolock
+   fun:map_images
+   fun:_ZN4dyldL18notifyBatchPartialE17dyld_image_statesbPFPKcS0_jPK15dyld_image_infoE
+   fun:_ZN4dyld36registerImageStateBatchChangeHandlerE17dyld_image_statesPFPKcS0_jPK15dyld_image_infoE
+   fun:dyld_register_image_state_change_handler
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_memdup_internal
+   fun:_ZL15fixupMethodListP13method_list_tbb
+   fun:_ZL17attachMethodListsP10objc_classPP13method_list_tibbb
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_read_images
+   fun:map_images_nolock
+   fun:map_images
+   fun:_ZN4dyldL18notifyBatchPartialE17dyld_image_statesbPFPKcS0_jPK15dyld_image_infoE
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_malloc
+   fun:_memdup_internal
+   fun:_ZL15fixupMethodListP13method_list_tbb
+   fun:_ZL17attachMethodListsP10objc_classPP13method_list_tibbb
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_class_getNonMetaClass
+   fun:lookUpImpOrForward
+   fun:objc_msgSend
+   fun:____CFSearchStringROM_block_invoke
+   fun:_dispatch_client_callout
+   fun:dispatch_once_f
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc_zone_malloc
+   fun:_CFRuntimeCreateInstance
+   fun:CFBasicHashCreate
+   fun:__CFInitialize
+   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
+   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
+   fun:_ZN4dyld24initializeMainExecutableEv
+   fun:_ZN4dyld5_mainEPK12macho_headermiPPKcS5_S5_Pm
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc_zone_calloc
+   fun:_ZL12realizeClassP10objc_class
+   fun:_ZL12realizeClassP10objc_class
+   fun:_class_getNonMetaClass
+   fun:lookUpImpOrForward
+   fun:objc_msgSend
+   fun:____CFSearchStringROM_block_invoke
+   fun:_dispatch_client_callout
+   fun:dispatch_once_f
+   fun:__CFStringCreateImmutableFunnel3
+   fun:CFStringCreateWithCString
+   fun:_CFBundleResourcesInitialize
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:ConnectToServer
+   fun:DNSServiceCreateConnection
+   fun:_mdns_search
+   fun:mdns_hostbyname
+   fun:search_host_byname
+   fun:gethostbyname
+   fun:_ZN6Dashel11IPV4AddressC2ERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEt
+   fun:_ZN6Dashel11IPV4AddressC1ERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEt
+   fun:_ZN6Dashel12SocketStreamC1ERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE
+   fun:_ZN6Dashel14createInstanceINS_12SocketStreamEEEPNS_6StreamERKNSt3__112basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEERKNS_3HubE
+   fun:_ZNK6Dashel18StreamTypeRegistry6createERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEES9_RKNS_3HubE
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:ConnectToServer
+   fun:DNSServiceCreateConnection
+   fun:_mdns_search
+   fun:mdns_hostbyaddr
+   fun:search_host_byaddr
+   fun:gethostbyaddr
+   fun:_ZNK6Dashel11IPV4Address6formatEb
+   fun:_ZN6Dashel3Hub4stepEi
+   fun:_ZN5Aseba13HttpInterface3runEv
+   fun:main
+}

--- a/tests/test-http.cpp
+++ b/tests/test-http.cpp
@@ -1,0 +1,286 @@
+/*
+ asebahttp - a switch to bridge HTTP to Aseba
+ 2014-12-01 David James Sherman <david dot sherman at inria dot fr>
+ 
+ Provide a simple REST interface with introspection for Aseba devices.
+
+ Unit tests:
+ 1. Aseba::HttpRequest object
+ 2. Aseba::HttpInterface hub -- "asebadummynode 0" must be running
+ 3. JSON parsing for integer arrays
+*/
+
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#include "catch.hpp"       // Catch is header-only
+#if defined(_WIN32) && defined(__MINGW32__)
+// Avoid conflict from /mingw32/.../include/winerror.h */
+#undef ERROR_STACK_OVERFLOW
+#endif
+#include "../switches/http/http.h"
+
+class Dummy: public Dashel::Hub
+{
+public:
+    Dummy()
+    {
+        instream = connect("file:name=testdata-HttpRequest.txt;mode=read");
+        outstream = connect("stdout:");
+    }
+    void connectionCreated(Dashel::Stream *stream) {};
+    void connectionClosed(Dashel::Stream *stream, bool abnormal) {};
+    void incomingData(Dashel::Stream *stream) {};
+    Dashel::Stream *instream, *outstream;
+};
+
+Dummy* dummy;
+
+TEST_CASE( "Dashel::Hub create" ) {
+    dummy = new Dummy;
+    REQUIRE( dummy->instream != NULL );
+}
+
+Aseba::HttpRequest req;
+
+TEST_CASE( "HttpRequest using default constructor", "[init]" ) {
+    REQUIRE( req.method.empty() );
+    REQUIRE( req.uri.empty() );
+    REQUIRE( req.stream == NULL );
+    REQUIRE( req.tokens.empty() );
+    REQUIRE( req.headers.empty() );
+    REQUIRE( req.content.empty() );
+}
+
+/*
+  Use Catch to write tests in Behavior-driven design (BDD) style
+*/
+
+SCENARIO( "HttpRequest should be initialized", "[init]" ) {
+    Dashel::Stream* cxn = dummy->instream;
+    
+    GIVEN( "HttpRequest initialized by string" ) {
+        req.initialize("GET /uri/a/b/c HTTP/1.1\r\n", cxn);
+        REQUIRE( req.method.find("GET")==0 );
+        REQUIRE( req.uri.find("/uri/a/b/c")==0 );
+        REQUIRE( req.tokens[1].find("a")==0 );
+        REQUIRE( req.stream == cxn );
+    }
+    GIVEN( "HttpRequest initialized by parts" ) {
+        req.initialize("GET", "/uri/a/b/c", "HTTP/1.0", cxn);
+        REQUIRE( req.method.find("GET")==0 );
+        REQUIRE( req.uri.find("/uri/a/b/c")==0 );
+        REQUIRE( req.tokens[1].find("a")==0 );
+        REQUIRE( req.stream == cxn );
+    }
+}
+
+SCENARIO( "HttpRequests should be read from file", "[read]" ) {
+    GIVEN( "Stream was initialized" ) {
+        REQUIRE( dummy->instream != NULL );
+        WHEN( "read request 1 from file" ) {
+            req.initialize(dummy->instream);
+            req.incomingData(); // from dummy->instream
+            THEN( "HttpRequest is correct" ) {
+                REQUIRE( req.ready );
+                REQUIRE( req.method.find("GET")==0 );
+                REQUIRE( req.uri.find("/uri/a/b/c")==0 );
+                REQUIRE( req.tokens[3].find("c")==0 );
+                REQUIRE( req.headers["Content-Length"].find("19")==0 );
+                REQUIRE( req.content.find("payload uri a b c\r\n")==0 );
+            }
+        }
+        AND_WHEN( "read request 2 from file" ) {
+            req.initialize(dummy->instream);
+            req.incomingData(); // from dummy->instream
+            THEN( "HttpRequest is correct" ) {
+                REQUIRE( req.ready );
+                REQUIRE( req.method.find("GET")==0 );
+                REQUIRE( req.uri.find("/uri")==0 );
+                REQUIRE( req.uri.size()==4 );
+                REQUIRE( req.tokens[0].find("uri")==0 );
+                REQUIRE( req.content.size()==0 );
+            }
+        }
+    }
+};
+
+TEST_CASE_METHOD(Aseba::HttpInterface, "Aseba::HttpInterface should be initialized", "[create]") {
+    REQUIRE( this != NULL );
+    for (int i = 50; --i; )
+        this->step(20);
+    REQUIRE( asebaStream != NULL );
+    REQUIRE( ! nodesDescriptions.empty() );
+    REQUIRE( nodesDescriptions[1].name.size() != 0 );
+};
+
+TEST_CASE_METHOD(Aseba::HttpInterface, "StreamResponseQueueMap should manage pending responses" ) {
+    Dashel::Stream* stream1 = (Dashel::Stream*)0x1111001;
+    Aseba::HttpRequest* req11 = new Aseba::HttpRequest;
+    Aseba::HttpRequest* req12 = new Aseba::HttpRequest;
+    Dashel::Stream* stream2 = (Dashel::Stream*)0x1111002;
+    Aseba::HttpRequest* req21 = new Aseba::HttpRequest;
+    Aseba::HttpRequest* req22 = new Aseba::HttpRequest;
+    Aseba::HttpRequest* req23 = new Aseba::HttpRequest;
+    GIVEN( "queue was initialized" ) {
+        REQUIRE( pendingResponses.size() == 0 );
+        WHEN( "insert pendingResponses responses in queues" ) {
+            scheduleResponse(stream1, req11);
+            scheduleResponse(stream1, req12);
+            scheduleResponse(stream2, req21);
+            scheduleResponse(stream2, req22);
+            scheduleResponse(stream2, req23);
+            THEN( "queues have correct values" ) {
+                REQUIRE( pendingResponses[stream1].size() == 2 );
+                Aseba::HttpInterface::ResponseQueue::iterator i1 = pendingResponses[stream1].begin();
+                REQUIRE( *i1++ == req11 );
+                REQUIRE( *i1   == req12 );
+                REQUIRE( pendingResponses[stream2].size() == 3 );
+                Aseba::HttpInterface::ResponseQueue::iterator i2 = pendingResponses[stream2].begin();
+                REQUIRE( *i2++ == req21 );
+                REQUIRE( *i2++ == req22 );
+                REQUIRE( *i2   == req23 );
+                WHEN( "update results" ) {
+                    finishResponse(req11, 200, "result 11");
+                    finishResponse(req12, 200, "result 12");
+                    finishResponse(req21, 201, "result 21");
+                    finishResponse(req22, 202, "result 22");
+                    finishResponse(req23, 203, "result 23");
+                    i1 = pendingResponses[stream1].begin();
+                    i2 = pendingResponses[stream2].begin();
+                    REQUIRE( (*i1++)->result == "result 11" );
+                    REQUIRE( (*i1  )->result == "result 12" );
+
+                    REQUIRE( (*i2  )->status == 201 );
+                    REQUIRE( (*i2++)->result == "result 21" );
+
+                    REQUIRE( (*i2  )->status == 202 );
+                    REQUIRE( (*i2++)->result == "result 22" );
+
+                    REQUIRE( (*i2  )->status == 203 );
+                    REQUIRE( (*i2  )->result == "result 23" );
+                    WHEN( "unschedule responses" ) {
+                        unscheduleResponse(stream2, req22);
+                        i2 = pendingResponses[stream2].begin();
+                        REQUIRE( (*i2++)->result == "result 21" );
+                        REQUIRE( (*i2  )->result == "result 23" );
+                        unscheduleResponse(stream1, req11);
+                        unscheduleResponse(stream1, req11);
+                        unscheduleResponse(stream1, req11);
+                        i1 = pendingResponses[stream1].begin();
+                        REQUIRE( (*i1)->result == "result 12" );
+                        unscheduleResponse(stream1, req12);
+                        REQUIRE( pendingResponses[stream1].size() == 0 );
+                        WHEN( "unschedule all responses") {
+                            REQUIRE( pendingResponses[stream2].size() == 2 );
+                            unscheduleAllResponses(stream2);
+                            REQUIRE( pendingResponses[stream2].size() == 0 );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+typedef std::vector<std::string> strings;
+
+TEST_CASE_METHOD(Aseba::HttpInterface, "JSON input is empty", "[empty]" ) {
+    std::string content = "";
+    strings values;
+    REQUIRE( values.size() == 0 );
+
+    GIVEN( "input is empty" ) {
+        parse_json_form(content, values); // no CHECK_THROWS because catch
+	REQUIRE( values.size() == 0 );
+    }
+}
+
+TEST_CASE_METHOD(Aseba::HttpInterface, "JSON input is integer array", "[array]" ) {
+    std::string content;
+    strings values;
+    REQUIRE( values.size() == 0 );
+
+    GIVEN( "a JSON array of one value " ) {
+        content = "[42]";
+        WHEN( "parse JSON string " + content ) {
+	    Aseba::HttpInterface::parse_json_form(content, values);
+            THEN( "array of single value 42 is returned" ) {
+	        REQUIRE( values.size() == 1 );
+	        REQUIRE( atoi(values[0].c_str()) == 42 );
+	    }
+        }
+    }
+    GIVEN( "a JSON array of zero values " ) {
+        content = "[]";
+        WHEN( "parse JSON string " + content ) {
+	    Aseba::HttpInterface::parse_json_form(content, values);
+            THEN( "an empty array is returned" ) {
+	        REQUIRE( values.size() == 0 );
+	    }
+        }
+    }
+    GIVEN( "a JSON array of four mixed values " ) {
+        content = "[42,63,27,\"hike\"]";
+        WHEN( "parse JSON string " + content ) {
+	    Aseba::HttpInterface::parse_json_form(content, values);
+            THEN( "array of four values is returned" ) {
+	        REQUIRE( values.size() == 0 );
+	    }
+        }
+    }
+    GIVEN( "a JSON array of two values with white space" ) {
+        content = " [\t42,\r\n\t 63\n\r]\t\n";
+        WHEN( "parse JSON string with white space " + content ) {
+	    Aseba::HttpInterface::parse_json_form(content, values);
+            THEN( "array of two values is returned" ) {
+	        REQUIRE( values.size() == 2 );
+	        REQUIRE( atoi(values[0].c_str()) == 42 );
+	        REQUIRE( atoi(values[1].c_str()) == 63 );
+	    }
+        }
+    }
+    GIVEN( "a malformed JSON array with a bad separator" ) {
+        content = "[42;63]";
+        WHEN( "parse JSON string with white space " + content ) {
+	    Aseba::HttpInterface::parse_json_form(content, values);
+            THEN( "an empty array is returned" ) {
+	        REQUIRE( values.size() == 0 );
+	    }
+        }
+    }
+    GIVEN( "a malformed JSON array with no opening" ) {
+        content = "42,63]";
+        WHEN( "parse JSON string with white space " + content ) {
+	    Aseba::HttpInterface::parse_json_form(content, values);
+            THEN( "an empty array is returned" ) {
+	        REQUIRE( values.size() == 0 );
+	    }
+        }
+    }
+    GIVEN( "a malformed JSON array with no close" ) {
+        content = "[42,63";
+        WHEN( "parse JSON string with white space " + content ) {
+	    Aseba::HttpInterface::parse_json_form(content, values);
+            THEN( "an empty array is returned" ) {
+	        REQUIRE( values.size() == 0 );
+	    }
+        }
+    }
+    GIVEN( "a JSON object" ) {
+        content = "{ \"abc\": 12, \"def\": [1,2,3] }";
+        WHEN( "parse JSON string " + content ) {
+            Aseba::HttpInterface::parse_json_form(content, values);
+            THEN( "an empty array is returned" ) {
+                REQUIRE( values.size() == 0 );
+            }
+        }
+    }
+    GIVEN( "a JSON array containing an object" ) {
+        content = "[42, { \"abc\": 12, \"def\": [1,2,3] }, 63]";
+        WHEN( "parse JSON string " + content ) {
+            Aseba::HttpInterface::parse_json_form(content, values);
+            THEN( "an empty array is returned" ) {
+                REQUIRE( values.size() == 0 );
+            }
+        }
+    }
+}

--- a/tests/testdata-HttpRequest.txt
+++ b/tests/testdata-HttpRequest.txt
@@ -1,0 +1,8 @@
+GET /uri/a/b/c HTTP/1.1
+Host: localhost
+Content-Length: 19
+
+payload uri a b c
+GET /uri HTTP/1.1
+Host: localhost
+


### PR DESCRIPTION
Provide a simple REST interface with introspection for Aseba devices.
 
    GET  /nodes                                 - JSON list of all known nodes
    GET  /nodes/:NODENAME                       - JSON attributes for :NODENAME
    PUT  /nodes/:NODENAME                       - install new Aesl program
    GET  /nodes/:NODENAME/:VARIABLE             - retrieve JSON value for :VARIABLE
    POST /nodes/:NODENAME/:VARIABLE             - send new values(s) for :VARIABLE
    POST /nodes/:NODENAME/:EVENT                - call an event :EVENT
    GET  /events[/:EVENT]*                      - create SSE stream for all known nodes
    GET  /nodes/:NODENAME/events[/:EVENT]*      - create SSE stream for :NODENAME
 
Typical use: `asebahttp -p 3000 -a vmcode.aesl ser:name=Thymio-II`

Variables and events are learned from the node description and parsed from AESL source when provided.
Server-side event (SSE) streams are updated as events arrive.
The two POST forms expect JSON, but also sloppily accept slash-delimited GET, for example 
* GET `/nodes/thymio-II/motor.left.target/100` sets the speed of the left motor
* GET `/nodes/thymio-II/sound_system/4/10` might record sound 4 for 10 seconds (if such an event were defined in AESL).

Compiled and tested on:
* MacOS Yosemite (clang-602.0.53)
* Ubuntu 12.04 (GNU g++ 4.6.3)
* Windows XP using MING32 under msys2-i686-20150202 (GNU g++ 4.9.2)

Unit tests (`tests/test-asebahttp`) require a dummy node at dashel target tcp:;port=33333.
They are defined using https://github.com/philsquared/Catch, which is included as a git submodule.