### PR TITLE
Fixed qMin type error for ARM

### DIFF
--- a/clients/studio/plugins/ThymioVPL/EventActionsSet.cpp
+++ b/clients/studio/plugins/ThymioVPL/EventActionsSet.cpp
@@ -1206,7 +1206,7 @@ namespace Aseba { namespace ThymioVPL
 			qreal h,s,v,a;
 			color.getHsvF(&h, &s, &v, &a);
 			s *= Style::blockDropAreaSaturationFactor;
-			v = qMin(1.0, v*Style::blockDropAreaValueFactor);
+			v = std::min<double>(1.0, v*Style::blockDropAreaValueFactor);
 			color.setHsvF(h,s,v,a);
 			//color.setAlpha(130);
 			painter->setPen(QPen(color, borderWidth, Qt::DotLine, Qt::RoundCap, Qt::RoundJoin));


### PR DESCRIPTION
Replace qMin by std::min<double> to work on ARM (on ARM qReal is float and not double)
This change should be compatible with all CPU architectures