### PR TITLE
asebahttp: verbose mode

### DIFF
--- a/switches/http/http.cpp
+++ b/switches/http/http.cpp
@@ -1057,13 +1057,13 @@ namespace Aseba
         for (StreamResponseQueueMap::iterator m = pendingResponses.begin();
              m != pendingResponses.end(); m++)
         {
-            if (verbose)
+            /*if (verbose)
             {
                 cerr << m->first << " sendAvailableResponses " << m->second.size() << " in queue";
                 for (ResponseQueue::iterator qi = m->second.begin(); qi != m->second.end(); qi++)
                     cerr << " " << *qi;
                 cerr << endl;
-            }
+            }*/
             bool close_this_stream = false;
             ResponseQueue* q = &(m->second);
             
@@ -1090,8 +1090,8 @@ namespace Aseba
                     q->pop_front();
                 }
             }
-            if (verbose)
-                cerr << m->first << " available responses sent, now " << m->second.size() << " in queue" << endl;
+            /*if (verbose)
+                cerr << m->first << " available responses sent, now " << m->second.size() << " in queue" << endl;*/
             
             if (close_this_stream)
                 streamsToShutdown.insert(m->first);

--- a/switches/http/http.cpp
+++ b/switches/http/http.cpp
@@ -134,13 +134,13 @@ namespace Aseba
     //-- Subclassing Dashel::Hub -----------------------------------------------------------
     
     
-    HttpInterface::HttpInterface(const std::string& asebaTarget, const std::string& http_port, const int iterations) :
+    HttpInterface::HttpInterface(const std::string& asebaTarget, const std::string& http_port, const int iterations, bool verbose) :
     Hub(false),  // don't resolve hostnames for incoming connections (there are a lot of them!)
     asebaStream(0),
     httpStream(0),
     nodeId(0),
     nodeDescriptionComplete(false),
-    verbose(false),
+    verbose(verbose),
     iterations(iterations)
     // created empty: pendingResponses, pendingVariables, eventSubscriptions, httpRequests, streamsToShutdown
     {

--- a/switches/http/http.h
+++ b/switches/http/http.h
@@ -83,7 +83,7 @@ namespace Aseba
         
     public:
         //default values needed for unit testing
-        HttpInterface(const std::string& target="tcp:127.0.0.1;port=33333", const std::string& http_port="3000", const int iterations=-1);
+        HttpInterface(const std::string& target="tcp:127.0.0.1;port=33333", const std::string& http_port="3000", const int iterations=-1, bool verbose = false);
         virtual void run();
         virtual bool descriptionReceived();
         virtual void broadcastGetDescription();

--- a/switches/http/main.cpp
+++ b/switches/http/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
     // create and run bridge, catch Dashel exceptions
     try
     {
-        Aseba::HttpInterface* network(new Aseba::HttpInterface(dashel_target, http_port, 1000*Kiterations));
+        Aseba::HttpInterface* network(new Aseba::HttpInterface(dashel_target, http_port, 1000*Kiterations, verbose));
         
         for (int i = 0; i < 500; i++)
             network->step(10); // wait for description, variables, etc

--- a/targets/challenge/challenge-textures.qrc
+++ b/targets/challenge/challenge-textures.qrc
@@ -13,6 +13,6 @@
 	<file>doc/challenge.fr.html</file>
 	<file>doc/challenge.es.html</file>
 	<file>doc/challenge.it.html</file>
-	<file>textures/asebachallenge.svgz</file
+	<file>textures/asebachallenge.svgz</file>
 </qresource>
 </RCC>


### PR DESCRIPTION
This update allows the user to launch asebahttp in verbose mode (-v option). 
To ease the debugging process, some repetitive output has been commented out.
