### PR TITLE
asebahttp: compilation errors

### DIFF
--- a/switches/http/http.h
+++ b/switches/http/http.h
@@ -93,7 +93,7 @@ namespace Aseba
         virtual void evLoad(HttpRequest* req, strings& args);
         virtual void evReset(HttpRequest* req, strings& args);
         virtual void aeslLoadFile(const std::string& filename);
-        virtual void aeslLoadMemory(const char* buffer, const int size);
+        virtual std::string aeslLoadMemory(const char* buffer, const int size);
         virtual void updateVariables(const std::string nodeName);
         
         virtual void scheduleResponse(Dashel::Stream* stream, HttpRequest* req);
@@ -115,14 +115,14 @@ namespace Aseba
         virtual void sendSetVariable(const std::string nodeName, const strings& args);
         virtual std::pair<unsigned,unsigned> sendGetVariables(const std::string nodeName, const strings& args);
         virtual bool getNodeAndVarPos(const std::string& nodeName, const std::string& variableName, unsigned& nodeId, unsigned& pos);
-        virtual void aeslLoad(xmlDoc* doc);
+        virtual std::string aeslLoad(xmlDoc* doc);
         virtual void incomingVariables(const Variables *variables);
         virtual void incomingUserMsg(const UserMessage *userMsg);
         virtual void routeRequest(HttpRequest* req);
         
         // helper functions
         bool getNodeAndVarPos(const std::string& nodeName, const std::string& variableName, unsigned& nodeId, unsigned& pos) const;
-        bool compileAndSendCode(const std::wstring& source, unsigned nodeId, const std::string& nodeName);
+        std::string compileAndSendCode(const std::wstring& source, unsigned nodeId, const std::string& nodeName);
         virtual void parse_json_form(std::string content, strings& values);
 
     };

--- a/targets/challenge/challenge-textures.qrc
+++ b/targets/challenge/challenge-textures.qrc
@@ -13,6 +13,6 @@
 	<file>doc/challenge.fr.html</file>
 	<file>doc/challenge.es.html</file>
 	<file>doc/challenge.it.html</file>
-	<file>textures/asebachallenge.svgz</file
+	<file>textures/asebachallenge.svgz</file>
 </qresource>
 </RCC>


### PR DESCRIPTION
By default, asebahttp returns `200: ok` to a `load` request whatever the outcome. However, in some cases the caller would be interested by the possible compilation errors. 

We modified the code so that the PUT data of a load request support a new argument: `verbose=true|false`. If set to true, the body of the response will contain compiler messages, or nothing if everything went well.

 Example:
-   `curl -X PUT --data-ascii "verbose=false,file=$(cat code.aesl)" http://localhost:3000/nodes/thymio-II/` behaves normally
-   `curl -X PUT --data-ascii "verbose=true,file=$(cat code.aesl)" http://localhost:3000/nodes/thymio-II/` returns an empty body upon  success and the error message (utf string) upon failure

Note that the verbose option should appear _before_ the file option for this to work.
