### PR TITLE
fix windows compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,9 @@ add_definitions(-DASEBA_ASSERT)
 # Remove -Wl,--no-undefined which CMake 3.0.2 (on OpenSUSE 13.2) adds to the
 # linker options when building shared libs. That breaks building libs that use
 # callbacks that will be provided by other libs when the executable is linked.
-STRING(REPLACE "-Wl,--no-undefined" "" CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
+if (DEFINED CMAKE_SHARED_LINKER_FLAGS)
+	STRING(REPLACE "-Wl,--no-undefined" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+endif (DEFINED CMAKE_SHARED_LINKER_FLAGS)
 
 # Dashel
 find_package(dashel REQUIRED)


### PR DESCRIPTION
CMAKE_SHARED_LINKER_FLAGS is not defined on windows