### PR TITLE
aseba-test-natives-count linking error on Linux

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_library(asebavmdummycallbacks STATIC
 	asebavmdummycallbacks.cpp
 )
-target_link_libraries(asebavmdummycallbacks ${ASEBA_CORE_LIBRARIES})
+target_link_libraries(asebavmdummycallbacks asebavm ${ASEBA_CORE_LIBRARIES})
 
 add_executable(asebatest
 	asebatest.cpp


### PR DESCRIPTION
The commit message for 337e7c5e2c2a10b44b38758d43feda61ac653420 states:
* [...]
* Fix dynamic link error when building aseba-test-natives-count
* [...]

However, as far as I can see it, all the components for these unit tests are statically linked, including *asebavm* and *asebadummycallbacks*. The problem is that there exists a circular dependency between those two libraries, which results in the following Linking error on current Debian testing, using GCC (Debian 5.2.1-17) and CMake 3.3.2:

```
[ 97%] Linking CXX executable aseba-test-natives-count
cd /home/fabian/Projects/aseba/build/tests && /usr/bin/cmake -E cmake_link_script CMakeFiles/aseba-test-natives-count.dir/link.txt --verbose=1
/usr/bin/c++   -g   CMakeFiles/aseba-test-natives-count.dir/aseba-test-natives-count.cpp.o  -o aseba-test-natives-count -rdynamic ../compiler/libasebacompiler.a ../vm/libasebavm.a libasebavmdummycallbacks.a ../transport/dashel_plugins/libasebadashelplugins.a ../common/libasebacommon.a /home/fabian/Projects/dashel/build/libdashel.a -ludev
libasebavmdummycallbacks.a(asebavmdummycallbacks.cpp.o): In function `AsebaAssert':
/home/fabian/Projects/aseba/tests/asebavmdummycallbacks.cpp:120: undefined reference to `AsebaVMInit'
collect2: error: ld returned 1 exit status
tests/CMakeFiles/aseba-test-natives-count.dir/build.make:101: recipe for target 'tests/aseba-test-natives-count' failed
```

The proposed commit fixes this linking issue by reverting the respective change to *tests/CMakeLists.txt* from 337e7c5e2c2a10b44b38758d43feda61ac653420, but since I do not know the reason for the original change, I cannot tell whether there will be any side effects on other build environments.