### PR TITLE
Fix building aseba-test-natives-count against static asebavm.

### DIFF
--- a/rpm/aseba.spec
+++ b/rpm/aseba.spec
@@ -9,7 +9,7 @@ Version:        %{source_major}.%{source_minor}.%{source_patch}
 
 # Update the following line with the git commit hash of the revision to use
 # for example by running git show-ref -s --tags RELEASE_TAG
-%global commit 04b42d4a5ead7ebe202786dcaf8f981275b712a9
+%global commit b2255c64be631fec2d71555a45043cfc60561d36
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 # Update the following line with the git commit has of the revision of Catch
@@ -31,7 +31,7 @@ Version:        %{source_major}.%{source_minor}.%{source_patch}
 # release version (i.e. the "Version:" line above refers to a future
 # source release version), then set the number to 0.0. Otherwise, leave the
 # the number unchanged. It will get bumped when you run rpmdev-bumpspec.
-Release:        0.2%{?snapshot}%{?dist}
+Release:        0.3%{?snapshot}%{?dist}
 Summary:        A set of tools which allow beginners to program robots easily and efficiently
 
 %global lib_pkg_name lib%{name}%{source_major}
@@ -183,6 +183,9 @@ fi
 %{_libdir}/*.so
 
 %changelog
+* Tue Oct 13 2015 Dean Brettle <dean@brettle.com> - 1.4.0-0.3.20151013gitb2255c6
+- Incorporate fixes needed by other platforms and package systems
+
 * Fri Sep 11 2015 Dean Brettle <dean@brettle.com> - 1.4.0-0.2.20150910git04b42d4
 - Sync with latest upstream master and fix build errors.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,17 @@
 add_library(asebavmdummycallbacks STATIC
 	asebavmdummycallbacks.cpp
 )
-target_link_libraries(asebavmdummycallbacks ${ASEBA_CORE_LIBRARIES})
+
+# If the asebavm is built as a shared lib, it must not be a dependency of
+# asebavmdummycallbacks because if it is, it will not be able to resolve refs
+# using asebavmdummycallbacks. On the other hand, if asabavm is not built as a
+# shared lib, it must be a dependency so that it can be used to resolve refs 
+# in asebavmdummycallbacks.
+if (BUILD_SHARED_LIBS)
+  target_link_libraries(asebavmdummycallbacks ${ASEBA_CORE_LIBRARIES})
+else (BUILD_SHARED_LIBS)
+  target_link_libraries(asebavmdummycallbacks asebavm ${ASEBA_CORE_LIBRARIES})
+endif (BUILD_SHARED_LIBS)
 
 add_executable(asebatest
 	asebatest.cpp


### PR DESCRIPTION
The essence of the problem is that there is a circular dependency between asebavm and asebavmdummycallbacks, and they need to be linked into aseba-test-natives-count differently depending on whether asebavm is built as a shared lib (which it is when building RPMS but not when building packages for Ubuntu/Debian). This pull request fixes the problem by just using an "if (BUILD_SHARED_LIBS)" in the CMakeLists.txt file to control the 2 different cases.

NOTE: I don't have an Ubuntu/Debian system to test on. Someone else needs to confirm that this works there.
