### PR TITLE
detect git repo even when in submodule

### DIFF
--- a/ParseVersion.cmake
+++ b/ParseVersion.cmake
@@ -52,27 +52,23 @@ endif (NOT GIT_FOUND)
 
 if (GIT_FOUND)
 	message("-- Git executable found")
-else (GIT_FOUND)
-	message("-- Git executable NOT found")
-endif (GIT_FOUND)
-
-if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git/")
-	set(HAS_GIT_REP 1)
-endif (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git/")
-
-# react accordingly
-if (GIT_FOUND AND HAS_GIT_REP)
-	message("-- Git repository found")
-	set(HAS_DYN_VERSION)
 	execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short --verify HEAD
 		OUTPUT_VARIABLE GIT_REV
 		ERROR_VARIABLE git_rev_error
 		RESULT_VARIABLE git_rev_result
 		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 		OUTPUT_STRIP_TRAILING_WHITESPACE)
-	if(NOT ${git_rev_result} EQUAL 0)
-		message(SEND_ERROR "Command \"${GIT_EXECUTABLE} rev-parse --short --verify HEAD\" failed with output:\n${git_rev_error}")
-	endif(NOT ${git_rev_result} EQUAL 0)
+	if(${git_rev_result} EQUAL 0)
+		set(HAS_GIT_REP 1)
+	endif(${git_rev_result} EQUAL 0)
+else (GIT_FOUND)
+	message("-- Git executable NOT found")
+endif (GIT_FOUND)
+
+# react accordingly
+if (GIT_FOUND AND HAS_GIT_REP)
+	message("-- Git repository found")
+	set(HAS_DYN_VERSION)
 	# write a file with the GIT_REV define
 	file(WRITE ${CMAKE_BINARY_DIR}/version.h.txt "#define ASEBA_BUILD_VERSION \"git-${GIT_REV}\"\n")
 	# write NSIS version file (for Windows build)


### PR DESCRIPTION
use git rev-parse to detect if we have a git repo, instead of looking for a .git folder (doesn't work if we are in a submodule)