### PR TITLE
Ignore proximity event blocks with grayed-out sensors

### DIFF
--- a/clients/studio/plugins/ThymioVPL/Block.cpp
+++ b/clients/studio/plugins/ThymioVPL/Block.cpp
@@ -168,6 +168,11 @@ namespace Aseba { namespace ThymioVPL
 		return false;
 	}
 	
+	bool Block::needsAnyValueSet() const
+	{
+		return false;
+	}
+	
 	void Block::resetValues()
 	{
 		for (unsigned i=0; i<valuesCount(); ++i)

--- a/clients/studio/plugins/ThymioVPL/Block.h
+++ b/clients/studio/plugins/ThymioVPL/Block.h
@@ -83,6 +83,7 @@ namespace Aseba { namespace ThymioVPL
 		virtual void setValue(unsigned i, int value) = 0;
 		virtual QVector<quint16> getValuesCompressed() const = 0;
 		virtual bool isAnyValueSet() const;
+		virtual bool needsAnyValueSet() const;
 		void resetValues();
 		
 		virtual bool isAdvancedBlock() const { return false; }

--- a/clients/studio/plugins/ThymioVPL/Compiler.cpp
+++ b/clients/studio/plugins/ThymioVPL/Compiler.cpp
@@ -23,6 +23,7 @@
 #include <QObject>
 #include "Compiler.h"
 #include "Scene.h"
+#include "Block.h"
 
 namespace Aseba { namespace ThymioVPL
 {
@@ -72,6 +73,10 @@ namespace Aseba { namespace ThymioVPL
 				else
 					return QObject::tr("The event and the state condition in line %0 are the same as in line %1").arg(errorLine+1).arg(referredLine+1);
 			}
+			case INEFFECTIVE_EVENT:
+			{
+				return QObject::tr("Line %0: No sensor selected, this line will never run").arg(errorLine+1);
+			}
 			default:
 				return QObject::tr("Unknown VPL error");
 		}
@@ -97,6 +102,11 @@ namespace Aseba { namespace ThymioVPL
 			// we need an event
 			if (!eventActionsSet.hasEventBlock())
 				return CompilationResult(MISSING_EVENT, errorLine);
+			
+			// some event blocks need at least one sensor selected
+			const Block* eventBlock = eventActionsSet.getEventBlock();
+			if (eventBlock->needsAnyValueSet() && !eventBlock->isAnyValueSet())
+				return CompilationResult(INEFFECTIVE_EVENT, errorLine);
 			
 			// we need at least one action
 			if (!eventActionsSet.hasAnyActionBlock())

--- a/clients/studio/plugins/ThymioVPL/Compiler.h
+++ b/clients/studio/plugins/ThymioVPL/Compiler.h
@@ -46,7 +46,8 @@ namespace Aseba { namespace ThymioVPL
 			NO_ERROR = 0,
 			MISSING_EVENT,
 			MISSING_ACTION,
-			DUPLICATED_EVENT
+			DUPLICATED_EVENT,
+			INEFFECTIVE_EVENT
 		};
 		
 		//! Result of a compilation

--- a/clients/studio/plugins/ThymioVPL/EventActionsSet.cpp
+++ b/clients/studio/plugins/ThymioVPL/EventActionsSet.cpp
@@ -1171,7 +1171,7 @@ namespace Aseba { namespace ThymioVPL
 		painter->setPen(Qt::NoPen);
 		//painter->setBrush(Qt::red);
 		painter->setBrush(QColor(Qt::red).lighter());
-		if (errorType == Compiler::MISSING_EVENT)
+		if (errorType == Compiler::MISSING_EVENT || errorType == Compiler::INEFFECTIVE_EVENT)
 		{
 			const qreal x(Style::blockSpacing + Style::blockWidth / 2);
 			const qreal y(Style::blockSpacing + Style::blockHeight + Style::blockSpacing + 20);

--- a/clients/studio/plugins/ThymioVPL/EventBlocks.cpp
+++ b/clients/studio/plugins/ThymioVPL/EventBlocks.cpp
@@ -68,6 +68,11 @@ namespace Aseba { namespace ThymioVPL
 		USAGE_LOG(logSignal(button,SIGNAL(stateChanged()),4,this));
 	}
 	
+	bool ArrowButtonsEventBlock::needsAnyValueSet() const
+	{
+		return true;
+	}
+	
 	// Prox Event
 	ProxEventBlock::ProxEventBlock(bool advanced, QGraphicsItem *parent) : 
 		BlockWithButtonsAndRange("event", "prox", true, PIXEL_TO_VAL_SQUARE, 700, 4000, 1000, 2000, Qt::black, Qt::white, advanced, parent)
@@ -132,6 +137,11 @@ namespace Aseba { namespace ThymioVPL
 		updateIndicationLEDsOpacity();
 	}
 	
+	bool ProxEventBlock::needsAnyValueSet() const
+	{
+		return true;
+	}
+	
 	
 	// Prox Ground Event
 	ProxGroundEventBlock::ProxGroundEventBlock(bool advanced, QGraphicsItem *parent) : 
@@ -164,6 +174,11 @@ namespace Aseba { namespace ThymioVPL
 		}
 		
 		updateIndicationLEDsOpacity();
+	}
+	
+	bool ProxGroundEventBlock::needsAnyValueSet() const
+	{
+		return true;
 	}
 	
 	

--- a/clients/studio/plugins/ThymioVPL/EventBlocks.h
+++ b/clients/studio/plugins/ThymioVPL/EventBlocks.h
@@ -34,18 +34,21 @@ namespace Aseba { namespace ThymioVPL
 	{
 	public:
 		ArrowButtonsEventBlock(QGraphicsItem *parent=0);
+		virtual bool needsAnyValueSet() const;
 	};
 	
 	class ProxEventBlock : public BlockWithButtonsAndRange
 	{
 	public:
 		ProxEventBlock(bool advanced, QGraphicsItem *parent=0);
+		virtual bool needsAnyValueSet() const;
 	};
 
 	class ProxGroundEventBlock : public BlockWithButtonsAndRange
 	{
 	public:
 		ProxGroundEventBlock(bool advanced, QGraphicsItem *parent=0);
+		virtual bool needsAnyValueSet() const;
 	};
 
 	class AccEventBlock : public Block

--- a/clients/studio/plugins/ThymioVPL/Scene.cpp
+++ b/clients/studio/plugins/ThymioVPL/Scene.cpp
@@ -510,7 +510,7 @@ namespace Aseba { namespace ThymioVPL
 		
 		const bool isWarning(
 			isSetLast(lastCompilationResult.errorLine) &&
-			((lastCompilationResult.errorType == Compiler::MISSING_ACTION) || (lastCompilationResult.errorType == Compiler::MISSING_EVENT))
+			((lastCompilationResult.errorType == Compiler::MISSING_ACTION) || (lastCompilationResult.errorType == Compiler::MISSING_EVENT) || (lastCompilationResult.errorType == Compiler::INEFFECTIVE_EVENT))
 		);
 		
 		warningGraphicsItem->setVisible(isWarning);

--- a/clients/studio/plugins/ThymioVPL/ThymioVisualProgramming.cpp
+++ b/clients/studio/plugins/ThymioVPL/ThymioVisualProgramming.cpp
@@ -975,6 +975,17 @@ namespace Aseba { namespace ThymioVPL
 			showCompilationError->show();
 			emit compilationOutcome(false);
 		}
+		else if ((compilation.errorType == Compiler::INEFFECTIVE_EVENT) && (scene->isSetLast(compilation.errorLine)))
+		{
+			compilationResult->setText(tr("Please select at least one sensor"));
+			compilationResult->setStyleSheet("QLabel { font-size: 10pt; }");
+			compilationResultImage->setPixmap(pixmapFromSVG(":/images/vpl/missing_block.svgz", fontSize*1.2));
+			runButton->setEnabled(false);
+			// error, cannot upload, stop animation
+			stopRunButtonAnimationTimer();
+			showCompilationError->show();
+			emit compilationOutcome(false);
+		}
 		else
 		{
 			compilationResult->setStyleSheet("QLabel { font-size: 10pt; color: rgb(231,19,0); }");


### PR DESCRIPTION
This implements the first part of what I suggested in #446, as a base for discussion: Proximity and button event blocks with all sensors grayed out should never trigger, rather than periodically, and cause a compiler warning.

It turns out that the current version of the VPL compiler is not capable of outputting warnings (while still generating code), only errors (which cause no code to be generated), so that’s what I implemented, as a first step. If there is agreement that that would be desirable, I can extend it to produce warnings instead. (MISSING_EVENT and MISSING_ACTION could be warnings too in my opinion, that would make it easier to test an incomplete program or “comment out” a line by removing its event or action.)

Is there anything I need to do to get the new UI strings internationalized? (I’m unfamiliar with Qt.)

If this is accepted, I will try to implement the second part: add a “periodic timer” block to replace the removed functionality.
