### PR TITLE
Silence various warnings on GCC 4.9.3

### DIFF
--- a/transport/can/can-buffer.c
+++ b/transport/can/can-buffer.c
@@ -23,12 +23,14 @@
 
 void AsebaSendBuffer(AsebaVMState *vm, const uint8* data, uint16 length)
 {
+	(void) vm;
 	while (AsebaCanSend(data, length) == 0)
 		AsebaIdle();
 }
 
 uint16 AsebaGetBuffer(AsebaVMState *vm, uint8* data, uint16 maxLength, uint16* source)
 {
+	(void) vm;
 	return AsebaCanRecv(data, maxLength, source);
 }
 

--- a/transport/can/can-buffer.c
+++ b/transport/can/can-buffer.c
@@ -20,7 +20,7 @@
 
 #include "../buffer/vm-buffer.h"
 #include "can-net.h"
-#include "common/consts.h"
+#include "../../common/consts.h"
 
 void AsebaSendBuffer(AsebaVMState *vm, const uint8* data, uint16 length)
 {

--- a/transport/can/can-buffer.c
+++ b/transport/can/can-buffer.c
@@ -20,17 +20,18 @@
 
 #include "../buffer/vm-buffer.h"
 #include "can-net.h"
+#include "common/consts.h"
 
 void AsebaSendBuffer(AsebaVMState *vm, const uint8* data, uint16 length)
 {
-	(void) vm;
+	ASEBA_UNUSED(vm);
 	while (AsebaCanSend(data, length) == 0)
 		AsebaIdle();
 }
 
 uint16 AsebaGetBuffer(AsebaVMState *vm, uint8* data, uint16 maxLength, uint16* source)
 {
-	(void) vm;
+	ASEBA_UNUSED(vm);
 	return AsebaCanRecv(data, maxLength, source);
 }
 

--- a/transport/can/can-net.c
+++ b/transport/can/can-net.c
@@ -75,7 +75,7 @@ uint16 AsebaCanGetMinMultipleOfHeight(uint16 v)
 }
 
 /*! Returned the number of used frames in the send queue*/
-static uint16 AsebaCanSendQueueGetUsedFrames()
+static uint16 AsebaCanSendQueueGetUsedFrames(void)
 {
 	uint16 ipos, cpos;
 	ipos = asebaCan.sendQueueInsertPos;
@@ -88,7 +88,7 @@ static uint16 AsebaCanSendQueueGetUsedFrames()
 }
 
 /*! Returned the number of free frames in the send queue */
-static uint16 AsebaCanSendQueueGetFreeFrames()
+static uint16 AsebaCanSendQueueGetFreeFrames(void)
 {
 	return asebaCan.sendQueueSize - AsebaCanSendQueueGetUsedFrames();
 }
@@ -109,7 +109,7 @@ static void AsebaCanSendQueueInsert(uint16 canid, const uint8 *data, size_t size
 }
 
 /*! Send frames in send queue to physical layer until it is full */
-static void AsebaCanSendQueueToPhysicalLayer()
+static void AsebaCanSendQueueToPhysicalLayer(void)
 {
 	uint16 temp;
 	
@@ -134,7 +134,7 @@ static void AsebaCanSendQueueToPhysicalLayer()
 }
 
 /*! Returned the maximum number of used frames in the reception queue*/
-static uint16 AsebaCanRecvQueueGetMaxUsedFrames()
+static uint16 AsebaCanRecvQueueGetMaxUsedFrames(void)
 {
 	uint16 ipos, cpos;
 	ipos = asebaCan.recvQueueInsertPos;
@@ -146,13 +146,13 @@ static uint16 AsebaCanRecvQueueGetMaxUsedFrames()
 }
 
 /*! Returned the minimum number of free frames in the reception queue */
-static uint16 AsebaCanRecvQueueGetMinFreeFrames()
+static uint16 AsebaCanRecvQueueGetMinFreeFrames(void)
 {
 	return asebaCan.recvQueueSize - AsebaCanRecvQueueGetMaxUsedFrames();
 }
 
 /*! Readjust the fifo pointers */
-static void AsebaCanRecvQueueGarbageCollect()
+static void AsebaCanRecvQueueGarbageCollect(void)
 {
 	uint16 temp;
 	while (asebaCan.recvQueueConsumePos != asebaCan.recvQueueInsertPos)
@@ -413,7 +413,7 @@ void AsebaCanFrameReceived(const CanFrame *frame)
 
 void AsebaCanRecvFreeQueue(void)
 {
-	int i;
+	size_t i;
 	for(i = 0; i < asebaCan.recvQueueSize; i++)
 		asebaCan.recvQueue[i].used = 0;
 	asebaCan.recvQueueInsertPos = 0;

--- a/transport/can/can-net.h
+++ b/transport/can/can-net.h
@@ -56,10 +56,10 @@ typedef struct
 } CanFrame;
 
 /*! Pointer to a void function */
-typedef void (*AsebaCanVoidVoidFP)();
+typedef void (*AsebaCanVoidVoidFP)(void);
 
 /*! Pointer to a void function returning int*/
-typedef int (*AsebaCanIntVoidFP)();
+typedef int (*AsebaCanIntVoidFP)(void);
 
 /*! Pointer to a function that sends a CAN frame (max 8 bytes) */
 typedef void (*AsebaCanSendFrameFP)(const CanFrame *frame);
@@ -123,7 +123,7 @@ uint16 AsebaShouldDropPacket(uint16 source, const uint8* data);
 void AsebaCanFrameReceived(const CanFrame *frame);
 
 /*! Data layer should call this function when the CAN frame (max 8 bytes) was sent successfully */
-void AsebaCanFrameSent();
+void AsebaCanFrameSent(void);
 
 /*! Return true if the recv buffer is empty, false otherwise */
 uint16 AsebaCanRecvBufferEmpty(void);

--- a/vm/natives.h
+++ b/vm/natives.h
@@ -200,7 +200,7 @@ extern const AsebaNativeFunctionDescription AsebaNativeDescription_vecnonzeroseq
 /*! Functon to set the seed of random generator */
 void AsebaSetRandomSeed(uint16 seed);
 /*! Functon to get a random number */
-uint16 AsebaGetRandom();
+uint16 AsebaGetRandom(void);
 /*! Function to get a 16-bit signed random number */
 void AsebaNative_rand(AsebaVMState *vm);
 /*! Description of AsebaNative_rand */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -149,6 +149,7 @@ static sint16 AsebaVMDoBinaryOperation(AsebaVMState *vm, sint16 valueOne, sint16
 
 static sint16 AsebaVMDoUnaryOperation(AsebaVMState *vm, sint16 value, uint16 op)
 {
+	(void) vm;
 	switch (op)
 	{
 		case ASEBA_UNARY_OP_SUB: return -value;
@@ -881,6 +882,7 @@ void AsebaVMDebugMessage(AsebaVMState *vm, uint16 id, uint16 *data, uint16 dataL
 
 uint16 AsebaVMShouldDropPacket(AsebaVMState *vm, uint16 source, const uint8* data)
 {
+	(void) source;
 	uint16 type = bswap16(((const uint16*)data)[0]);
 	if (type < 0x8000)
 	{

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -149,7 +149,7 @@ static sint16 AsebaVMDoBinaryOperation(AsebaVMState *vm, sint16 valueOne, sint16
 
 static sint16 AsebaVMDoUnaryOperation(AsebaVMState *vm, sint16 value, uint16 op)
 {
-	(void) vm;
+	ASEBA_UNUSED(vm);
 	switch (op)
 	{
 		case ASEBA_UNARY_OP_SUB: return -value;
@@ -882,7 +882,7 @@ void AsebaVMDebugMessage(AsebaVMState *vm, uint16 id, uint16 *data, uint16 dataL
 
 uint16 AsebaVMShouldDropPacket(AsebaVMState *vm, uint16 source, const uint8* data)
 {
-	(void) source;
+	ASEBA_UNUSED(source);
 	uint16 type = bswap16(((const uint16*)data)[0]);
 	if (type < 0x8000)
 	{


### PR DESCRIPTION
When building latest Aseba master on ARM Cortex-M several warnings are produced. This PR fixes all of them and should not induce any behaviour changes.