### PR TITLE
Ignore start address record in hexfiles

### DIFF
--- a/common/utils/HexFile.cpp
+++ b/common/utils/HexFile.cpp
@@ -219,6 +219,26 @@ namespace Aseba
 						throw WrongCheckSum(lineCounter, checkSum, computedCheckSum);
 				}
 				break;
+
+				case 5: // start linear address record
+				{
+					// Start linear address record are not used by the Aseba
+					// bootloader protocol so we can ignore them.
+
+					// Skip data
+					for (int i = 0; i < 4; i++)
+						computedCheckSum += getUint8(ifs);
+
+					computedCheckSum = 1 + ~computedCheckSum;
+
+					uint8 checkSum = getUint8(ifs);
+
+					if (checkSum != computedCheckSum)
+						throw WrongCheckSum(lineCounter, checkSum, computedCheckSum);
+				}
+
+				break;
+
 				
 				default:
 				throw UnknownRecordType(lineCounter, recordType);


### PR DESCRIPTION
arm-none-eabi-objcopy emits that type of record to indicate program entry point. I think it should be ignored because otherwise it rejects perfectly valid files.