### PR TITLE
asebadummynode can request ephemeral ports

### DIFF
--- a/targets/dummy/dummynode.cpp
+++ b/targets/dummy/dummynode.cpp
@@ -313,13 +313,12 @@ extern "C" void AsebaAssert(AsebaVMState *vm, AsebaAssertReason reason)
 
 int usage(char* program)
 {
-	std::cerr << "Usage: " << program << " [--basePort|-b BASE, default 33333] [ID, from 0 to 9]" << std::endl;
-	std::cerr << "Usage: " << program << " --port|-p PORT [ID, from 0 to 9]" << std::endl;
+	std::cerr << "Usage: " << program << " [--port|-p PORT] [ID, from 0 to 9]" << std::endl;
 	std::cerr << "Usage: " << program << " --help|-h" << std::endl;
 	std::cerr << "Creates one node dummynode-ID with node id ID+1 listening on port:" << std::endl;
-	std::cerr << " - BASE+ID, if BASE != 0 and BASE+ID is available" << std::endl;
+	std::cerr << " - a dynamically chosen port, if PORT == 0" << std::endl;
 	std::cerr << " - PORT, if PORT != 0 and PORT is available" << std::endl;
-	std::cerr << " - a dynamically chosen port, if PORT or BASE == 0." << std::endl;
+	std::cerr << " - 33333+ID, if PORT is not set and 33333+ID is available." << std::endl;
 	std::cerr << "The Dashel target is printed on stdout." << std::endl;
 	return 1;
 }
@@ -327,29 +326,26 @@ int usage(char* program)
 int main(int argc, char* argv[])
 {
 	int port(ASEBA_DEFAULT_PORT);
-	bool do_delta(false);
+	bool do_delta(true);
 	int deltaNodeId(0);
 
 	int argCounter = 1;
 	while (argCounter < argc)
 	{
 		const char *arg = argv[argCounter++];
-		if ((strcmp(arg, "-b") == 0) || (strcmp(arg, "--basePort") == 0))
-			do_delta = (port = atoi(argv[argCounter++]));
-		else if ((strcmp(arg, "-p") == 0) || (strcmp(arg, "--port") == 0))
+		if ((strcmp(arg, "-p") == 0) || (strcmp(arg, "--port") == 0))
 			do_delta = false, port = atoi(argv[argCounter++]);
 		else if ((strcmp(arg, "-h") == 0) || (strcmp(arg, "--help") == 0))
 			return usage(argv[0]);
 		else
 		{
 			deltaNodeId = atoi(arg);
-			if (deltaNodeId < 0 || deltaNodeId >= 9)
+			if (deltaNodeId < 0 || deltaNodeId > 9)
 				return usage(argv[0]);
 		}
 	}
 
-	Dashel::Stream* listen = node.listen(do_delta ? port+deltaNodeId : port,
-					     deltaNodeId);
+	Dashel::Stream* listen = node.listen(do_delta ? port+deltaNodeId : port, deltaNodeId);
 
 	std::cout << "tcp:port=" << listen->getTargetParameter("port") << std::endl;
 

--- a/targets/dummy/dummynode.cpp
+++ b/targets/dummy/dummynode.cpp
@@ -82,29 +82,32 @@ public:
 		vm.variablesSize = sizeof(variables) / sizeof(sint16);
 	}
 	
-	void listen(int basePort, int deltaPort)
+	Dashel::Stream* listen(const int port, int deltaNodeId)
 	{
-		const int port(basePort + deltaPort);
-		vm.nodeId = 1 + deltaPort;
+		vm.nodeId = 1 + deltaNodeId;
 		strncpy(mutableName, "dummynode-0", 12);
-		mutableName[10] = '0' + deltaPort;
+		mutableName[10] = '0' + deltaNodeId;
 		nodeDescription.name = mutableName;
+		Dashel::Stream* listen_stream;
 		
 		// connect network
 		try
 		{
 			std::ostringstream oss;
 			oss << "tcpin:port=" << port;
-			Dashel::Hub::connect(oss.str());
+			listen_stream = Dashel::Hub::connect(oss.str());
 		}
 		catch (Dashel::DashelException e)
 		{
 			std::cerr << "Cannot create listening port " << port << ": " << e.what() << std::endl;
 			abort();
 		}
-		
+
 		// init VM
 		AsebaVMInit(&vm);
+
+		// return stream
+		return listen_stream;
 	}
 	
 	virtual void connectionCreated(Dashel::Stream *stream)
@@ -308,20 +311,47 @@ extern "C" void AsebaAssert(AsebaVMState *vm, AsebaAssertReason reason)
 	AsebaVMInit(vm);
 }
 
+int usage(char* program)
+{
+	std::cerr << "Usage: " << program << " [--basePort|-b BASE, default 33333] [ID, from 0 to 9]" << std::endl;
+	std::cerr << "Usage: " << program << " --port|-p PORT [ID, from 0 to 9]" << std::endl;
+	std::cerr << "Usage: " << program << " --help|-h" << std::endl;
+	std::cerr << "Creates one node dummynode-ID with node id ID+1 listening on port:" << std::endl;
+	std::cerr << " - BASE+ID, if BASE != 0 and BASE+ID is available" << std::endl;
+	std::cerr << " - PORT, if PORT != 0 and PORT is available" << std::endl;
+	std::cerr << " - a dynamically chosen port, if PORT or BASE == 0." << std::endl;
+	std::cerr << "The Dashel target is printed on stdout." << std::endl;
+	return 1;
+}
 
 int main(int argc, char* argv[])
 {
-	const int basePort = ASEBA_DEFAULT_PORT;
-	int deltaPort = 0;
-	if (argc > 1)
+	int port(ASEBA_DEFAULT_PORT);
+	bool do_delta(false);
+	int deltaNodeId(0);
+
+	int argCounter = 1;
+	while (argCounter < argc)
 	{
-		deltaPort = atoi(argv[1]);
-		if (deltaPort < 0 || deltaPort >= 9)
+		const char *arg = argv[argCounter++];
+		if ((strcmp(arg, "-b") == 0) || (strcmp(arg, "--basePort") == 0))
+			do_delta = (port = atoi(argv[argCounter++]));
+		else if ((strcmp(arg, "-p") == 0) || (strcmp(arg, "--port") == 0))
+			do_delta = false, port = atoi(argv[argCounter++]);
+		else if ((strcmp(arg, "-h") == 0) || (strcmp(arg, "--help") == 0))
+			return usage(argv[0]);
+		else
 		{
-			std::cerr << "Usage: " << argv[0] << " [delta port, from 0 to 9]" << std::endl;
-			return 1;
+			deltaNodeId = atoi(arg);
+			if (deltaNodeId < 0 || deltaNodeId >= 9)
+				return usage(argv[0]);
 		}
 	}
-	node.listen(basePort, deltaPort);
+
+	Dashel::Stream* listen = node.listen(do_delta ? port+deltaNodeId : port,
+					     deltaNodeId);
+
+	std::cout << "tcp:port=" << listen->getTargetParameter("port") << std::endl;
+
 	node.run();
 }

--- a/targets/dummy/dummynode.cpp
+++ b/targets/dummy/dummynode.cpp
@@ -82,7 +82,7 @@ public:
 		vm.variablesSize = sizeof(variables) / sizeof(sint16);
 	}
 	
-	Dashel::Stream* listen(const int port, int deltaNodeId)
+	Dashel::Stream* listen(const int port, const int deltaNodeId)
 	{
 		vm.nodeId = 1 + deltaNodeId;
 		strncpy(mutableName, "dummynode-0", 12);


### PR DESCRIPTION
First part of issue #544: asebadummynode now can ask for an ephemeral port using the `--port 0` option. Additionally, the `--basePort` option allows one to start numbering anywhere, not just 33333.
```
% asebadummynode -p 0
tcp:port=59048
% asebadummynode -p 20000 1
tcp:port=20000
% asebadummynode -b 20000 2
tcp:port=20002
% asebadummynode
tcp:port=33333
```
This PR depends on Dashel >= 1.2.0 in order to correctly print the target with the generated port number; otherwise, it is reported as `tcp:port=0`.

```
Usage: asebadummynode [--basePort|-b BASE, default 33333] [ID, from 0 to 9]
Usage: asebadummynode --port|-p PORT [ID, from 0 to 9]
Usage: asebadummynode --help|-h
Creates one node dummynode-ID with node id ID+1 listening on port:
 - BASE+ID, if BASE != 0 and BASE+ID is available
 - PORT, if PORT != 0 and PORT is available
 - a dynamically chosen port, if PORT or BASE == 0.
The Dashel target is printed on stdout.
```