### PR TITLE
register apidocs with each operation

### DIFF
--- a/switches/http2/http/HttpDispatcher.h
+++ b/switches/http2/http/HttpDispatcher.h
@@ -66,6 +66,7 @@ namespace Aseba
 		void optionsHandler(HandlerContext& context);
 		void getTestHandler(HandlerContext& context);
 		void getApiDocs(HandlerContext& context);
+		virtual json buildApiDocs();
 		
 		// TODO: add handler support class
 		

--- a/switches/http2/http/HttpDispatcher.h
+++ b/switches/http2/http/HttpDispatcher.h
@@ -60,6 +60,7 @@ namespace Aseba
 		
 	protected:
 		void registerHandler(const Handler& handler, const HttpMethod& method, const strings& uriPath);
+		void registerHandler(const Handler& handler, const HttpMethod& method, const strings& uriPath, const json& apidoc);
 		
 		// options and test
 		void optionsHandler(HandlerContext& context);
@@ -98,6 +99,9 @@ namespace Aseba
 		typedef std::map<HttpMethod, URIHandlerMap> HandlersMap;
 		//! Handlers for known method + URI couples
 		HandlersMap handlers;
+		//! Map of method, split URI to JSON-formatted OAS documentation
+		typedef std::map<HttpMethod, std::map<strings, json>> ApidocsMap;
+		ApidocsMap apidocs;
 	};
 }
 


### PR DESCRIPTION
The apidocs for each operation comprise at least seven fields, including a map that defines every response code the operation can produce. Since this information is contained the JSON-formatted OAS specification for the REST API, it is easiest to provide the apidocs in JSON format.

These fragments are easy to extract using `jq`; for example, POST /constants is
```
jq -c '.paths."/constants".post' aseba-v1.json
```

This PR adds an `apidocs` map parallel to `handlers`, and a variant `registerHandler` that accepts apidocs. It also modifies `getApidocs` to provide global OAS information about the API.

(TODO: include model definitions, for $ref schema references.)