### PR TITLE
Playground: Use new Enki viewer with picking

### DIFF
--- a/targets/challenge/challenge.cpp
+++ b/targets/challenge/challenge.cpp
@@ -641,7 +641,6 @@ namespace Enki
 				camera.yaw += 2*M_PI;
 			camera.pitch = -M_PI/7;
 		}
-		ViewerWidget::timerEvent(event);
 	}
 /*
 	void ChallengeViewer::mouseMoveEvent ( QMouseEvent * event )

--- a/targets/playground/PlaygroundViewer.h
+++ b/targets/playground/PlaygroundViewer.h
@@ -32,6 +32,8 @@
 #include <viewer/Viewer.h>
 #include <QProcess>
 
+#include <QMainWindow>
+
 #define LOG_COLOR(t,c) Enki::PlaygroundViewer::getInstance()->log(t,c)
 #define LOG_INFO(t) Enki::PlaygroundViewer::getInstance()->log(t,Qt::white)
 #define LOG_WARN(t) Enki::PlaygroundViewer::getInstance()->log(t,Qt::yellow)
@@ -43,7 +45,7 @@ namespace Enki
 {
 	class World;
 	
-	class PlaygroundViewer : public ViewerWidget
+	class PlaygroundViewer : public QMainWindow
 	{
 		Q_OBJECT
 		
@@ -53,16 +55,24 @@ namespace Enki
 		QColor logColor[LOG_HISTORY_COUNT];
 		Aseba::UnifiedTime logTime[LOG_HISTORY_COUNT];
 		unsigned logPos;
+		const int timerPeriodMs;
 		unsigned energyPool;
-		
+
+		ViewerWidget* viewer;
+
 	public:
 		PlaygroundViewer(World* world);
 		virtual ~PlaygroundViewer();
 		
 		World* getWorld() const;
+		ViewerWidget* getViewer();
 		static PlaygroundViewer* getInstance();
 		
 		void log(const QString& entry, const QColor& color);
+		void timerEvent(QTimerEvent* event);
+		void startSimulation();
+		void setCamera(QPointF planPosition, double altitude, double yaw, double pitch);
+		void keyPressEvent(QKeyEvent* event);
 		
 	public slots:
 		void processStarted();

--- a/targets/playground/playground.cpp
+++ b/targets/playground/playground.cpp
@@ -177,6 +177,7 @@ int main(int argc, char *argv[])
 	
 	// Create viewer
 	Enki::PlaygroundViewer viewer(&world);
+	viewer.resize(1000, 800);
 	
 	// Scan for camera
 	QDomElement cameraE = domDocument.documentElement().firstChildElement("camera");
@@ -395,8 +396,14 @@ int main(int argc, char *argv[])
 		procssE = procssE.nextSiblingElement("process");
 	}
 	
+	// Allow picking for objects with finite mass
+	for (auto o: world.objects)
+		if (o->getMass() != -1)
+			viewer.getViewer()->setMovableByPicking(o, true);
+	
 	// Show and run
 	viewer.setWindowTitle("Playground - Stephane Magnenat (code) - Basilio Noris (gfx)");
+	viewer.startSimulation();
 	viewer.show();
 	
 	// If D-Bus is used, register the viewer object


### PR DESCRIPTION
This PR extracts from Titwin/aseba-INRIA@e2a61a832ae37955c5715472fa494712c594009b a minimal set of changes to allow Aseba Playground to use the new Enki viewer with picking. The new Enki viewer is not a drop-in replacement for Enki 2.0.0 and changes to client code are needed.

Changes in this PR:
- QTimerEvents must hand off to the new `Enki::ViewerWidget::timerEvent`, which counts milliseconds. If timer events are not handled correctly, picking will not work. A `StartSimulation` hook is used to start the timer.
- `Aseba::PlaygroundViewer` is a QMainWindow with a layout. It is not a derived class of `Enki::ViewerWidget` but does contain one.
- Playground objects with finite mass are flagged as movable by picking.

Note that [Titwin/aseba-INRIA master](https://github.com/Titwin/aseba-INRIA/tree/master) contains other improvements to the GUI that are not included in this PR.

TODO: add a check for the Enki version (which version?) in [targets/playground/CMakeLists.txt](https://github.com/davidjsherman/aseba/blob/playground-picking/targets/playground/CMakeLists.txt). If we want backwards compatibility with Enki 2.0.0, we will need to add conditional compilation in 7 places.
