### PR TITLE
Mask conflicting symbol from mingw32 corerror.h (Windows error codes)

### DIFF
--- a/compiler/errors_code.h
+++ b/compiler/errors_code.h
@@ -2,6 +2,11 @@
 #ifndef __ERRORS_H
 #define __ERRORS_H
 
+// Mask conflict with /mingw32/i686-w64-mingw32/include/corerror.h (Windows error codes)
+#ifdef WIN32
+#undef ERROR_STACK_OVERFLOW
+#endif
+
 /*
 This file was automatically generated. Do not modify it,
 or your changes will be lost!

--- a/maintainer/translations/02_sync_compiler_translation.py
+++ b/maintainer/translations/02_sync_compiler_translation.py
@@ -36,6 +36,11 @@ output_code_file = \
 #ifndef __ERRORS_H
 #define __ERRORS_H
 
+// Mask conflict with /mingw32/i686-w64-mingw32/include/corerror.h (Windows error codes)
+#ifdef WIN32
+#undef ERROR_STACK_OVERFLOW
+#endif
+
 /*
 This file was automatically generated. Do not modify it,
 or your changes will be lost!


### PR DESCRIPTION
Windows error codes in /mingw32/i686-w64-mingw32/include/corerror.h also
define ERROR_STACK_OVERFLOW, which conflicts with symbols defined by
the Aseba compiler. Mask the Windows symbol that I think we don't need.