### PR TITLE
Use a consistent organization name and domain.

### DIFF
--- a/clients/studio/main.cpp
+++ b/clients/studio/main.cpp
@@ -58,8 +58,8 @@ int main(int argc, char *argv[])
 	Dashel::initPlugins();
 	
 	// Information used by QSettings with default constructor
-	QCoreApplication::setOrganizationName("EPFL-LSRO-Mobots");
-	QCoreApplication::setOrganizationDomain("mobots.epfl.ch");
+	QCoreApplication::setOrganizationName(ASEBA_ORGANIZATION_NAME);
+	QCoreApplication::setOrganizationDomain(ASEBA_ORGANIZATION_DOMAIN);
 	QCoreApplication::setApplicationName("Aseba Studio");
 
 	QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));

--- a/clients/studio/thymiovpl.cpp
+++ b/clients/studio/thymiovpl.cpp
@@ -77,8 +77,8 @@ int main(int argc, char *argv[])
 	Dashel::initPlugins();
 	
 	// Information used by QSettings with default constructor
-	QCoreApplication::setOrganizationName("EPFL-LSRO-Mobots");
-	QCoreApplication::setOrganizationDomain("mobots.epfl.ch");
+	QCoreApplication::setOrganizationName(ASEBA_ORGANIZATION_NAME);
+	QCoreApplication::setOrganizationDomain(ASEBA_ORGANIZATION_DOMAIN);
 	QCoreApplication::setApplicationName("Thymio VPL");
 
 	QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));

--- a/common/consts.h
+++ b/common/consts.h
@@ -26,6 +26,7 @@
 */
 /*@{*/
 
+
 /*! version of Aseba as string */
 #define ASEBA_VERSION "1.5.98"
 
@@ -49,6 +50,12 @@
 
 /*! default port for aseba */
 #define ASEBA_DEFAULT_PORT 33333
+
+/*! Name of the organization supporting Aseba and related software*/
+#define ASEBA_ORGANIZATION_NAME "Aseba community"
+
+/*! Domain of the organization supporting Aseba and related software*/
+#define ASEBA_ORGANIZATION_DOMAIN "aseba.io"
 
 
 /*! List of bytecodes identifiers */

--- a/targets/playground/playground.cpp
+++ b/targets/playground/playground.cpp
@@ -128,7 +128,8 @@ struct RobotType
 int main(int argc, char *argv[])
 {
 	QApplication app(argc, argv);
-	app.setOrganizationName("Aseba"); // FIXME: we should be consistent here
+	QCoreApplication::setOrganizationName(ASEBA_ORGANIZATION_NAME);
+	QCoreApplication::setOrganizationDomain(ASEBA_ORGANIZATION_DOMAIN);
 	app.setApplicationName("Playground");
 	
 	QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));


### PR DESCRIPTION
Note this is a breaking change as it changes the location of
QSettings-based settings stores.

Fix #734