### PR TITLE
Handle reconnecting a target while the Web Server is running

### DIFF
--- a/switches/http/http.h
+++ b/switches/http/http.h
@@ -72,7 +72,8 @@ namespace Aseba
         typedef std::map<unsigned, std::wstring>                NodeIdProgramMap;
 
     protected:
-        // streams
+        std::map<std::string, Dashel::Stream*> streamInitParameters;
+        std::map<std::string, unsigned> targetsToNodeId;
         StreamNodeIdMap             asebaStreams;
         Dashel::Stream*             inHttpStream;
         Dashel::Stream*             inAsebaStream;
@@ -162,6 +163,8 @@ namespace Aseba
         virtual void parse_json_form(const std::string content, strings& values);
         std::vector<unsigned> getIdsFromURI(const strings& args);
         Dashel::Stream* getStreamFromNodeId(const unsigned nodeId);
+        void discardStream(Dashel::Stream* stream);
+        std::string targetFromString(Dashel::Stream* stream) const;
     };
     
     class HttpRequest


### PR DESCRIPTION
Handle disconnecting and reconnecting a device in `asebahttp`.
Only works for targets associated with a constant node id across reconnection.
Typically it will works great for Thymio, less so for simulated robots.
The intent is to offer a workable solution for the 1.6 release, not to be a long term solution.