### PR TITLE
Jenkinsfile new parallel syntax, use artifacts, record test results

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# emacs: -*- CMake -*-
 # kate: replace-tabs off; tab-width 4; indent-width 4; tab-indents true; indent-mode normal
 # vim: ts=4:sw=4:noexpandtab
 
@@ -116,6 +117,9 @@ if (DNSSD_FOUND)
 		set(ASEBA_ZEROCONF_ADDITIONAL_LIBRARIES ${AVAHI_CLIENT_LIBRARIES} ${AVAHI_COMMON_LIBRARIES} ${DNSSD_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 	else()
 		set(ASEBA_ZEROCONF_ADDITIONAL_LIBRARIES ${DNSSD_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+		if (WIN32)
+			set(ASEBA_ZEROCONF_ADDITIONAL_LIBRARIES ${ASEBA_ZEROCONF_ADDITIONAL_LIBRARIES} -lws2_32)
+		endif()
 	endif()
 	set(ASEBA_ZEROCONF_LIBRARIES asebazeroconf ${ASEBA_ZEROCONF_ADDITIONAL_LIBRARIES})
 	if (QT4_FOUND)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
 	agent any
 
 	// Jenkins will prompt for parameters when a branch is build manually
-	// but will use default parameters when the entire project is built.
 	parameters {
 		string(defaultValue: 'aseba-community/dashel/master', description: 'Dashel project', name: 'project_dashel')
 		string(defaultValue: 'enki-community/enki/master', description: 'Enki project', name: 'project_enki')
@@ -27,13 +26,17 @@ pipeline {
 
 				// Dashel and Enki are retrieved from archived artifacts
 				script {
+					// Failsafe values for the benefit of automatic jobs
+					def pr_dashel = env.project_dashel ?: 'aseba-community/dashel/master'
+					def pr_enki = env.project_enki ?: 'enki-community/enki/master'
+
 					def p = ['debian','macos','windows'].collectEntries{
 						[ (it): {
 								node(it) {
-									copyArtifacts projectName: "${env.project_dashel}",
+									copyArtifacts projectName: "${pr_dashel}",
 										  filter: 'dist/'+it+'/**',
 										  selector: lastSuccessful()
-									copyArtifacts projectName: "${env.project_enki}",
+									copyArtifacts projectName: "${pr_enki}",
 										  filter: 'dist/'+it+'/**',
 										  selector: lastSuccessful()
 									stash includes: 'dist/**', name: 'dist-externals-' + it

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,171 +3,106 @@
 // Jenkinsfile for compiling, testing, and packaging Aseba.
 // Requires CMake plugin from https://github.com/davidjsherman/aseba-jenkins.git in global library.
 
-// Ideally we should unarchive Dashel and Enki libraries that were previously compiled by other
-// Jenkins jobs, but for now we conservatively recompile them.
-
 pipeline {
 	agent any
 
 	// Jenkins will prompt for parameters when a branch is build manually
 	// but will use default parameters when the entire project is built.
 	parameters {
-		string(defaultValue: 'master', description: 'Dashel branch', name: 'branch_dashel')
-		string(defaultValue: 'master', description: 'Enki branch', name: 'branch_enki')
+		string(defaultValue: 'aseba-community/dashel/master', description: 'Dashel project', name: 'project_dashel')
+		string(defaultValue: 'enki-community/enki/master', description: 'Enki project', name: 'project_enki')
 	}
 	
+	// Everything will be built in the build/ directory.
+	// Everything will be installed in the dist/ directory.
 	stages {
 		stage('Prepare') {
 			steps {
-				echo "branch_dashel=${env.branch_dashel}"
-				echo "branch_enki=${env.branch_enki}"
+				echo "project_dashel=${env.project_dashel}"
+				echo "project_enki=${env.project_enki}"
 
-				// Dashel and Enki will be checked out into the externals/ directory.
-				sh 'mkdir -p externals'
-				dir('aseba') {
-					checkout scm
-					sh 'git submodule update --init'
-				}
-				dir('externals/dashel') {
-					git branch: "${env.branch_dashel}", url: 'https://github.com/aseba-community/dashel.git'
-				}
-				dir('externals/enki') {
-					git branch: "${env.branch_enki}", url: 'https://github.com/enki-community/enki.git'
-				}
-				stash excludes: '.git', includes: 'aseba/**,externals/**', name: 'source'
-			}
-		}
-		// Everything will be built in the build/ directory.
-		// Everything will be installed in the dist/ directory.
-		stage('Dashel') {
-			steps {
-				parallel (
-					"debian" : {
-						node('debian') {
-							unstash 'source'
-							CMake([sourceDir: pwd()+'/externals/dashel', label: 'debian', preloadScript: 'set -x',
-								buildDir: pwd()+'/build/dashel/debian'])
-							stash includes: 'dist/**', name: 'dist-dashel-debian'
-						}
-					},
-					"macos" : {
-						node('macos') {
-							// sh 'rm -rf build/* dist/*'
-							unstash 'source'
-							CMake([sourceDir: pwd()+'/externals/dashel', label: 'macos', preloadScript: 'set -x',
-								buildDir: pwd()+'/build/dashel/macos'])
-							stash includes: 'dist/**', name: 'dist-dashel-macos'
-						}
-					},
-					"windows" : {
-						node('windows') {
-							// sh 'rm -rf build/* dist/*'
-							unstash 'source'
-							CMake([sourceDir: pwd()+'/externals/dashel', label: 'windows', preloadScript: 'set -x',
-								buildDir: pwd()+'/build/dashel/windows'])
-							stash includes: 'dist/**', name: 'dist-dashel-windows'
-						}
-					}
-				)
-			}
-		}
-		stage('Enki') {
-			steps {
-				parallel (
-					"debian" : {
-						node('debian') {
-							unstash 'source'
-							script {
-								env.debian_python = sh ( script: '''
-									python -c "import sys; print 'lib/python'+str(sys.version_info[0])+'.'+str(sys.version_info[1])+'/dist-packages'"
-								''', returnStdout: true).trim()
+				// Jenkins will automatically check out the source
+				// Fixme: Stashed source includes .git otherwise submodule update fails
+				sh 'git submodule update --init'
+
+				// Dashel and Enki are retrieved from archived artifacts
+				script {
+					def p = ['debian','macos','windows'].collectEntries{
+						[ (it): {
+								node(it) {
+									copyArtifacts projectName: "${env.project_dashel}",
+										  filter: 'dist/'+it+'/**',
+										  selector: lastSuccessful()
+									copyArtifacts projectName: "${env.project_enki}",
+										  filter: 'dist/'+it+'/**',
+										  selector: lastSuccessful()
+									stash includes: 'dist/**', name: 'dist-externals-' + it
+								}
 							}
-							CMake([sourceDir: pwd()+'/externals/enki', label: 'debian', preloadScript: 'set -x',
-								getCmakeArgs: "-DPYTHON_CUSTOM_TARGET:PATH=${env.debian_python}",
-								buildDir: pwd()+'/build/enki/debian'])
-							stash includes: 'dist/**', name: 'dist-enki-debian'
-						}
-					},
-					"macos" : {
-						node('macos') {
-							unstash 'source'
-							CMake([sourceDir: pwd()+'/externals/enki', label: 'macos', preloadScript: 'set -x',
-								buildDir: pwd()+'/build/enki/macos'])
-							stash includes: 'dist/**', name: 'dist-enki-macos'
-						}
-					},
-					"windows" : {
-						node('windows') {
-							unstash 'source'
-							CMake([sourceDir: pwd()+'/externals/enki', label: 'windows', preloadScript: 'set -x',
-								buildDir: pwd()+'/build/enki/windows'])
-							stash includes: 'dist/**', name: 'dist-enki-windows'
-						}
+						]
 					}
-				)
+					parallel p;
+				}
 			}
 		}
 		stage('Compile') {
-			steps {
-				parallel (
-					"debian" : {
-						node('debian') {
-							unstash 'dist-dashel-debian'
-							unstash 'dist-enki-debian'
-							script {
-								env.debian_dashel_DIR = sh ( script: 'dirname $(find $PWD/dist/debian -name dashelConfig.cmake | head -1)', returnStdout: true).trim()
-								env.debian_enki_DIR = sh ( script: 'dirname $(find $PWD/dist/debian -name enkiConfig.cmake | head -1)', returnStdout: true).trim()
-							}
-							unstash 'source'
-							CMake([sourceDir: pwd()+'/aseba', label: 'debian', preloadScript: 'set -x',
-								envs: [ "dashel_DIR=${env.debian_dashel_DIR}", "enki_DIR=${env.debian_enki_DIR}" ] ])
-							stash includes: 'dist/**', name: 'dist-aseba-debian'
-							stash includes: 'build/**', name: 'build-aseba-debian'
-						}
-					},
-					"macos" : {
-						node('macos') {
-							unstash 'dist-dashel-macos'
-							unstash 'dist-enki-macos'
-							script {
-								env.macos_dashel_DIR = sh ( script: 'dirname $(find $PWD/dist/macos -name dashelConfig.cmake | head -1)', returnStdout: true).trim()
-								env.macos_enki_DIR = sh ( script: 'dirname $(find $PWD/dist/macos -name enkiConfig.cmake | head -1)', returnStdout: true).trim()
-							}
-							echo "Found dashel_DIR=${env.dashel_DIR} enki_DIR=${env.enki_DIR}"
-							unstash 'source'
-							CMake([sourceDir: pwd()+'/aseba', label: 'macos', preloadScript: 'set -x',
-								envs: [ "dashel_DIR=${env.macos_dashel_DIR}", "enki_DIR=${env.macos_enki_DIR}" ] ])
-							stash includes: 'dist/**', name: 'dist-aseba-macos'
-							stash includes: 'build/**', name: 'build-aseba-macos'
-						}
-					},
-					"windows" : {
-						node('windows') {
-							unstash 'dist-dashel-windows'
-							unstash 'dist-enki-windows'
-							script {
-								env.windows_dashel_DIR = sh ( script: 'dirname $(find $PWD/dist/windows -name dashelConfig.cmake | head -1)', returnStdout: true).trim()
-								env.windows_enki_DIR = sh ( script: 'dirname $(find $PWD/dist/windows -name enkiConfig.cmake | head -1)', returnStdout: true).trim()
-							}
-							unstash 'source'
-							CMake([sourceDir: pwd()+'/aseba', label: 'windows', preloadScript: 'set -x',
-								envs: [ "dashel_DIR=${env.windows_dashel_DIR}", "enki_DIR=${env.windows_enki_DIR}" ] ])
-							stash includes: 'dist/**', name: 'dist-aseba-windows'
-							// stash includes: 'build/**', name: 'build-aseba-windows'
-						}
+			parallel {
+				stage("Compile on debian") {
+					agent {
+						label 'debian'
 					}
-				)
+					steps {
+						sh 'git submodule update --init'
+						unstash 'dist-externals-debian'
+						CMake([label: 'debian'])
+						stash includes: 'dist/**', name: 'dist-aseba-debian'
+						stash includes: 'build/**', name: 'build-aseba-debian'
+					}
+				}
+				stage("Compile on macos") {
+					agent {
+						label 'macos'
+					}
+					steps {
+						sh 'git submodule update --init'
+						unstash 'dist-externals-macos'
+						script {
+							env.macos_enki_DIR = sh ( script: 'dirname $(find $PWD/dist/macos -name enkiConfig.cmake | head -1)', returnStdout: true).trim()
+						}
+						echo "macos_enki_DIR=${env.macos_enki_DIR}"
+						CMake([label: 'macos',
+							   envs: [ "enki_DIR=${env.macos_enki_DIR}" ] ])
+						stash includes: 'dist/**', name: 'dist-aseba-macos'
+					}
+				}
+				stage("Compile on windows") {
+					agent {
+						label 'windows'
+					}
+					steps {
+						sh 'git submodule update --init'
+						unstash 'dist-externals-windows'
+						CMake([label: 'windows'])
+						stash includes: 'dist/**', name: 'dist-aseba-windows'
+					}
+				}
 			}
 		}
-		stage('Test') {
+		stage('Smoke Test') {
 			// Only do some tests. To do: add test labels in CMakeLists to distinguish between
 			// obligatory smoke tests (to be done for every PR) and extended tests only for
 			// releases or for end-to-end testing.
-			steps {
-				node('debian') {
-					unstash 'build-aseba-debian'
-					dir('build/debian') {
-						sh "LANG=en_US.UTF-8 ctest -E 'e2e.*|simulate.*|.*http.*|valgrind.*'"
+			parallel {
+				stage("Smoke test on debian") {
+					agent {
+						label 'debian'
+					}
+					steps {
+						unstash 'build-aseba-debian'
+						dir('build/debian') {
+							sh "LANG=en_US.UTF-8 ctest -T Test -E 'e2e.*|simulate.*|.*http.*|valgrind.*'"
+						}
+						stash includes: 'build/debian/Testing/**', name: 'test-results', allowEmpty: true
 					}
 				}
 			}
@@ -179,76 +114,35 @@ pipeline {
 					return env.BRANCH == 'master'
 				}
 			}
-			steps {
-				node('debian') {
-					unstash 'build-aseba-debian'
-					dir('build/debian') {
-						sh "LANG=en_US.UTF-8 ctest -R 'e2e.*|simulate.*|.*http.*|valgrind.*'"
+			parallel {
+				stage("Extended test on debian") {
+					agent {
+						label 'debian'
+					}
+					steps {
+						unstash 'build-aseba-debian'
+						dir('build/debian') {
+							sh "LANG=en_US.UTF-8 ctest -T Test -R 'e2e.*|simulate.*|.*http.*|valgrind.*'"
+						}
+						stash includes: 'build/debian/Testing/**', name: 'test-results', allowEmpty: true
 					}
 				}
 			}
 		}
-		stage('Package') {
-			// Packages are only built for the master branch
-			when {
-				expression {
-					return env.BRANCH == 'master'
-				}
-			}
-			steps {
-				parallel (
-					"debian-pack" : {
-						node('docker') {
-							script {
-								docker.image('aseba/buildfarm').inside {
-									unstash 'source'
-									sh '''
-										(cd externals/dashel && debuild -i -us -uc -b && sudo dpkg -i ../libdashel*.deb)
-										(cd externals/enki && debuild -i -us -uc -b && sudo dpkg -i ../libenki*.deb)
-										(cd aseba && debuild -i -us -uc -b)
-										exit 0
-									'''
-								}
-							}
-							archiveArtifacts artifacts: 'aseba*.deb', fingerprint: true, onlyIfSuccessful: true
-						}
-					},
-					"macos-pack" : {
-						node('macos') {
-							unstash 'build-aseba-macos'
-							git branch: 'inherit-env', url: 'https://github.com/davidjsherman/aseba-osx.git'
-							sh '''
-								[ -d source ] || ln -s . source
-								export your_qt_path=$(otool -L dist/macos/bin/asebastudio | grep QtCore | perl -pe "s{\\s*(/.*)lib/QtCore.*}{\\$1}")
-								export your_qwt_path=$(otool -L dist/macos/bin/asebastudio | grep qwt.framework | perl -pe "s{\\s*(/.*)lib/QtCore.*}{\\$1}")
-								export your_certificate=none
-								mkdir -p build/packager &&
-									(cd build/packager && bash -x ../../packager/packager_script && mv Aseba*.dmg ../..)
-							'''
-							archiveArtifacts artifacts: 'Aseba*.dmg', fingerprint: true, onlyIfSuccessful: true
-						}
-					}
-				)
-			}
-		}
+		// No stage('Package'), packaging is handled by a separate job
 		stage('Archive') {
 			steps {
-				// Show how to do this with an array of parallel steps, rather that explictly with parallel()
-				script {
-					// Can't use collectEntries yet [JENKINS-26481], so use a loop accumulating into an array
-					def p = [:]
-					for (x in ['debian','macos','windows']) {
-						def label = x		// capture loop variable (CPS bug)
-						p[label+'-archive'] = {
-							node(label) {
-								unstash 'dist-aseba-' + label
-								archiveArtifacts artifacts: 'dist/**', fingerprint: true, onlyIfSuccessful: true
-							}
-						}
-					}
-					parallel p;
-				}
+				unstash 'dist-aseba-debian'
+				unstash 'dist-aseba-macos'
+				unstash 'dist-aseba-windows'
+				archiveArtifacts artifacts: 'dist/**', fingerprint: true, onlyIfSuccessful: true
 			}
+		}
+	}
+	post {
+		always {
+			unstash 'test-results'
+			step([$class: 'XUnitPublisher', testTimeMargin: '3000', thresholdMode: 1, thresholds: [[$class: 'FailedThreshold', failureNewThreshold: '', failureThreshold: '', unstableNewThreshold: '', unstableThreshold: '5'], [$class: 'SkippedThreshold', failureNewThreshold: '', failureThreshold: '', unstableNewThreshold: '', unstableThreshold: '']], tools: [[$class: 'CTestType', deleteOutputFiles: true, failIfNotNew: false, pattern: 'build/debian/Testing/*/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true]]])
 		}
 	}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,10 +71,12 @@ pipeline {
 						unstash 'dist-externals-macos'
 						script {
 							env.macos_enki_DIR = sh ( script: 'dirname $(find $PWD/dist/macos -name enkiConfig.cmake | head -1)', returnStdout: true).trim()
+							env.macos_dashel_DIR = sh ( script: 'dirname $(find $PWD/dist/macos -name dashelConfig.cmake | head -1)', returnStdout: true).trim()
 						}
 						echo "macos_enki_DIR=${env.macos_enki_DIR}"
+						echo "macos_dashel_DIR=${env.macos_dashel_DIR}"
 						CMake([label: 'macos',
-							   envs: [ "enki_DIR=${env.macos_enki_DIR}" ] ])
+							   envs: [ "enki_DIR=${env.macos_enki_DIR}", "dashel_DIR=${env.macos_dashel_DIR}" ] ])
 						stash includes: 'dist/**', name: 'dist-aseba-macos'
 					}
 				}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,17 @@ pipeline {
 		string(defaultValue: 'aseba-community/dashel/master', description: 'Dashel project', name: 'project_dashel')
 		string(defaultValue: 'enki-community/enki/master', description: 'Enki project', name: 'project_enki')
 	}
+
+	// Trigger the build
+	triggers {
+		// Poll GitHub every two hours, in case webhooks aren't used
+		pollSCM('H */2 * * *')
+		// Rebuild if Dashel or Enki masters have been rebuilt
+		upstream(
+			upstreamProjects: 'aseba-community/dashel/master,enki-community/enki/master',
+			threshold: hudson.model.Result.SUCCESS
+		)
+	}
 	
 	// Everything will be built in the build/ directory.
 	// Everything will be installed in the dist/ directory.


### PR DESCRIPTION
Jenkinsfile using the new [declarative parallel stages](https://jenkins.io/blog/2017/09/25/declarative-1/) for debian, macos, windows. Relies on davidjsherman/aseba-jenkins@e6c2eb6a6b5e262f072671d04717466945f3fb30 _et seq._. 

Dashel and Enki are not compiled, but retrieved by Jenkins as artifacts from {aseba,enki}-community projects. Rely on CMAKE_FIND_ROOT_PATH to find Dashel and Enki. On macOS there is a hack for Enki [Jenkinsfile#L70](https://github.com/davidjsherman/aseba/blob/master/Jenkinsfile#L70).

Windows dnssd needs ws2_32, see [CMakeLists.txt#L121](https://github.com/davidjsherman/aseba/blob/master/CMakeLists.txt#L121).

Testing results from CTest are recorded, and published using xUnit. Publishing is done in a post stage ([Jenkinsfile#L142](https://github.com/davidjsherman/aseba/blob/master/Jenkinsfile#L142)), so always happens even if the pipeline fails.