### PR TITLE
Static stdlibcpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,14 @@ if (DEFINED CMAKE_SHARED_LINKER_FLAGS)
 	STRING(REPLACE "-Wl,--no-undefined" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
 endif (DEFINED CMAKE_SHARED_LINKER_FLAGS)
 
+
+if (UNIX)
+    if (ASEBA_STATICLIBSTDC)
+		set(CMAKE_EXE_LINKER_FLAGS "-static-libstdc++")
+		set(CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++")
+	endif ()
+endif ()
+
 # testing and defines
 enable_testing()
 add_definitions(-Wall)

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Stephane Magnenat <stephane@nospam.magnenant.net>
 Section:devel
 Priority:optional
 Standards-Version: 3.7.2
-Build-Depends: cmake (>=2.6), libdashel (>=1.1.0), libenki (>=2.0~git.20180109), libqt4-dev, libqt4-opengl-dev, libqtwebkit-dev, qt4-dev-tools, libqwt5-qt4-dev, libudev-dev, libxml2-dev, libsdl2-dev, libavahi-compat-libdnssd-dev
+Build-Depends: cmake (>=2.6), libdashel (>=1.1.0), libenki (>=2.0~git.20180109), libqt4-dev, libqt4-opengl-dev, libqtwebkit-dev, qt4-dev-tools, libqwt5-qt4-dev, libudev-dev, libxml2-dev, libsdl2-dev, libavahi-compat-libdnssd-dev, g++ (>=5.0) | g++-5 | g++-7
 
 Package:aseba
 Architecture: any


### PR DESCRIPTION
the debian/rules should be something like

```
cd debian/build && cmake -D USER_BUILD_VERSION=${DEBVERS} -DASEBA_STATICLIBSTDC:BOOL=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../tmp/usr -DCMAKE_CXX_COMPILER=g++-5 -DCMAKE_C_COMPILER=gcc-5 ../..
```

Note sure you we could express that in a generic manner (aka only for the compiler when we have no choice)