### PR TITLE
Playground: testing multi-node networks

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ add_subdirectory(compiler)
 add_subdirectory(vm)
 add_subdirectory(simulator)
 #add_subdirectory(e2e-http)
-
+add_subdirectory(e2e-playground)
 
 # test asebahttp
 # FIXME: port to asebahttp2

--- a/tests/e2e-playground/CMakeLists.txt
+++ b/tests/e2e-playground/CMakeLists.txt
@@ -1,0 +1,53 @@
+# End-to-end testing of Aseba Playground multi-node networks
+
+
+# Test multi-node networks
+
+# 1. using processes
+add_test(NAME e2e-playground-1-processes
+	COMMAND bash run-e2e-playground.sh test-1-processes.playground)
+set_tests_properties(e2e-playground-1-processes PROPERTIES TIMEOUT 90)
+
+# 2. using proposed <networks> tag: expected to fail
+add_test(NAME e2e-playground-2-networks
+	COMMAND bash run-e2e-playground.sh test-2-networks.playground)
+set_tests_properties(e2e-playground-2-networks PROPERTIES TIMEOUT 90 WILL_FAIL true)
+
+
+# Create test fixtures
+
+# 1. test program with correct target utilities
+add_custom_command(
+	OUTPUT run-e2e-playground.sh
+	COMMAND ${CMAKE_COMMAND}
+		-D in=${CMAKE_CURRENT_SOURCE_DIR}/run-e2e-playground.sh.in
+		-D out=${CMAKE_CURRENT_BINARY_DIR}/run-e2e-playground.sh
+		-D ASEBAPLAYGROUND=$<TARGET_FILE:asebaplayground> 
+		-D ASEBADUMP=$<TARGET_FILE:asebadump> 
+		-P ${CMAKE_CURRENT_SOURCE_DIR}/../patch-script.cmake
+	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/run-e2e-playground.sh.in
+)
+add_custom_target(create-run-e2e-playground ALL DEPENDS run-e2e-playground.sh)
+
+# 2. patch test-1-processes.playground with correct target utilities
+add_custom_command(
+	OUTPUT test-1-processes.playground
+	COMMAND ${CMAKE_COMMAND}
+		-D in=${CMAKE_CURRENT_SOURCE_DIR}/test-1-processes.playground.in
+		-D out=${CMAKE_CURRENT_BINARY_DIR}/test-1-processes.playground
+		-D ASEBAMASSLOADER=$<TARGET_FILE:asebamassloader> 
+		-D ASEBASWITCH=$<TARGET_FILE:asebaswitch> 
+		-D ASEBAHTTP=$<TARGET_FILE:asebahttp> 
+		-P ${CMAKE_CURRENT_SOURCE_DIR}/../patch-script.cmake
+	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/test-1-processes.playground.in
+)
+add_custom_target(create-test-1-processes ALL DEPENDS test-1-processes.playground)
+
+# 3. other assets are copied
+configure_file(test-2-networks.playground ${CMAKE_CURRENT_BINARY_DIR}/test-2-networks.playground COPYONLY)
+configure_file(beacon-solo.aesl ${CMAKE_CURRENT_BINARY_DIR}/beacon-solo.aesl COPYONLY)
+configure_file(beacon-net.aesl ${CMAKE_CURRENT_BINARY_DIR}/beacon-net.aesl COPYONLY)
+configure_file(README.md ${CMAKE_CURRENT_BINARY_DIR}/README.md COPYONLY)
+

--- a/tests/e2e-playground/README.md
+++ b/tests/e2e-playground/README.md
@@ -1,0 +1,20 @@
+# End-to-end testing of Aseba Playground
+
+## Creating multi-node networks
+
+The testing scenario comprises five simulated Thymio-II robots partitioned into three networks.
+
+1. A solo node with a program loaded from an Aesl file
+2. A two-node network with separate programs loaded from an external Aesl file 
+3. A two-node network with separate programs specified from an Aesl network whose definition is inlined in the Playground
+
+The programs are simple beacons, that broadcast an **alive** message with the id of the node evry three seconds. They can be tested by connecting **asebadump** to the network and watching for events.
+```
+for i in 01 02 13 23; do asebadump tcp:port=333$i | head -5; done
+```
+
+The Playground files provide two ways of building the same networks.
+* *test-1-processes.playground* runs Aseba utilities as separate processes, to join the nodes with switches and to install the programs;
+* *test-2-networks.playground* declares the networks using a proposed extension of the Playground XML definition.
+
+The latter is meant to fail at the present time, because the proposed extension is not yet implemented.

--- a/tests/e2e-playground/beacon-net.aesl
+++ b/tests/e2e-playground/beacon-net.aesl
@@ -1,0 +1,14 @@
+<!DOCTYPE aesl-source>
+<network>
+<event size="1" name="alive"/>
+<node nodeId="1" name="thymio-II">
+timer.period=[3000,0]
+onevent timer0
+emit alive([1])
+</node>
+<node nodeId="2" name="thymio-II">
+timer.period=[3000,0]
+onevent timer0
+emit alive([2])
+</node>
+</network>

--- a/tests/e2e-playground/beacon-solo.aesl
+++ b/tests/e2e-playground/beacon-solo.aesl
@@ -1,0 +1,9 @@
+<!DOCTYPE aesl-source>
+<network>
+<event size="1" name="alive"/>
+<node nodeId="1" name="thymio-II">
+timer.period=[3000,0]
+onevent timer0
+emit alive([1])
+</node>
+</network>

--- a/tests/e2e-playground/run-e2e-playground.sh.in
+++ b/tests/e2e-playground/run-e2e-playground.sh.in
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+[ "$MSYSTEM" = "MINGW32" ] && TCP="tcp:127.0.0.1" || TCP="tcp:"
+
+# clean up previous session
+which killall >/dev/null 2>&1 \
+    && killall aseba{playground,switch,massloader,dump} \
+    || ps | egrep 'aseba(playground|switch|massloader|dump)' | while read pid rest; do kill $pid; done
+
+# start Playground with specified file
+playground=${1:-test.playground}
+@ASEBAPLAYGROUND@ ${playground} &
+sleep 10
+
+# check each network for node beacons
+@ASEBADUMP@ $TCP';port=33301' | head -6 | grep -m1 '0000 user message from 1 : user message of size 1 :    1' &&
+@ASEBADUMP@ $TCP';port=33313' | head -6 | grep -m1 '0000 user message from 1 : user message of size 1 :    1' && sleep 2 &&
+@ASEBADUMP@ $TCP';port=33313' | head -6 | grep -m1 '0000 user message from 2 : user message of size 1 :    2' &&
+@ASEBADUMP@ $TCP';port=33323' | head -20 | grep -m1 '0000 user message from 1 : user message of size 1 :    1' && sleep 2 &&
+@ASEBADUMP@ $TCP';port=33323' | head -20 | grep -m1 '0000 user message from 2 : user message of size 1 :    2'
+status=$?
+
+# clean up
+[ -z "$(jobs -p)" ] || kill %%
+
+exit $status

--- a/tests/e2e-playground/test-1-processes.playground
+++ b/tests/e2e-playground/test-1-processes.playground
@@ -1,0 +1,27 @@
+<!DOCTYPE aseba-playground>
+<!-- Aseba playground for testing creation of multi-node networks. -->
+<!-- 1. Solo node with a program loaded from an Aesl file -->
+<!-- 2. Two-node network with separate programs loaded from an Aesl file -->
+<!-- 3. Two-node network with separate programs specified from an inlined Aesl network -->
+
+<!-- Test 1: Load programs using Aseba utilities running in separate processes -->
+<!-- The test succeeds if the nodes in the three networks emit an alive event every 3 seconds -->
+
+<aseba-playground>
+	<world w="60" h="80" />
+
+	<robot type="thymio2" port="33301" x="20" y="20" nodeId="1" id="T1" name="Test Solo Single" />
+	<process command=":asebamassloader --once beacon-solo.aesl tcp:localhost;33301" />
+
+	<robot type="thymio2" port="33311" x="20" y="40" nodeId="1" id="T2" name="Test Net File 1" />
+	<robot type="thymio2" port="33312" x="40" y="40" nodeId="2" id="T3" name="Test Net File 2" />
+	<process command=":asebaswitch -p 33313 -n Network-Aesl-File tcp:localhost;33311 tcp:localhost;33312" />
+	<process command=":asebamassloader --once beacon-net.aesl tcp:localhost;33313" />
+
+	<robot type="thymio2" port="33321" x="20" y="60" nodeId="1" id="T4" name="Test Net Inline 1" />
+	<robot type="thymio2" port="33322" x="40" y="60" nodeId="2" id="T5" name="Test Net Inline 2" />
+	<process command=":asebaswitch -p 33323 -n Network-Aesl-Inline tcp:localhost;33321 tcp:localhost;33322" />
+	<process command=":asebahttp --autorestart --http 3002 tcp:localhost;33323" />
+	<process command="curl --retry 3 --header Content-Type:&#9;application/octet-stream --data-ascii &lt;!DOCTYPE&#9;aesl-source&gt;&#9;&lt;network&gt;&#9;&lt;event&#9;size=&quot;1&quot;&#9;name=&quot;alive&quot;/&gt;&#9;&lt;node&#9;nodeId=&quot;1&quot;&#9;name=&quot;thymio-II&quot;&gt;&#9;timer.period=[3000,0]&#9;onevent&#9;timer0&#9;emit&#9;alive([1])&#9;&lt;/node&gt;&#9;&lt;/network&gt;&#9; -X PUT http://127.0.0.1:3002/nodes/1" />
+	<process command="curl --retry 3 --header Content-Type:&#9;application/octet-stream --data-ascii &lt;!DOCTYPE&#9;aesl-source&gt;&#9;&lt;network&gt;&#9;&lt;event&#9;size=&quot;1&quot;&#9;name=&quot;alive&quot;/&gt;&#9;&lt;node&#9;nodeId=&quot;1&quot;&#9;name=&quot;thymio-II&quot;&gt;&#9;timer.period=[3000,0]&#9;onevent&#9;timer0&#9;emit&#9;alive([2])&#9;&lt;/node&gt;&#9;&lt;/network&gt;&#9; -X PUT http://127.0.0.1:3002/nodes/2" />
+</aseba-playground>

--- a/tests/e2e-playground/test-1-processes.playground.in
+++ b/tests/e2e-playground/test-1-processes.playground.in
@@ -1,0 +1,27 @@
+<!DOCTYPE aseba-playground>
+<!-- Aseba playground for testing creation of multi-node networks. -->
+<!-- 1. Solo node with a program loaded from an Aesl file -->
+<!-- 2. Two-node network with separate programs loaded from an Aesl file -->
+<!-- 3. Two-node network with separate programs specified from an inlined Aesl network -->
+
+<!-- Test 1: Load programs using Aseba utilities running in separate processes -->
+<!-- The test succeeds if the nodes in the three networks emit an alive event every 3 seconds -->
+
+<aseba-playground>
+	<world w="60" h="80" />
+
+	<robot type="thymio2" port="33301" x="20" y="20" nodeId="1" id="T1" name="Test Solo Single" />
+	<process command="@ASEBAMASSLOADER@ --once beacon-solo.aesl tcp:localhost;33301" />
+
+	<robot type="thymio2" port="33311" x="20" y="40" nodeId="1" id="T2" name="Test Net File 1" />
+	<robot type="thymio2" port="33312" x="40" y="40" nodeId="2" id="T3" name="Test Net File 2" />
+	<process command="@ASEBASWITCH@ -p 33313 -n Network-Aesl-File tcp:localhost;33311 tcp:localhost;33312" />
+	<process command="@ASEBAMASSLOADER@ --once beacon-net.aesl tcp:localhost;33313" />
+
+	<robot type="thymio2" port="33321" x="20" y="60" nodeId="1" id="T4" name="Test Net Inline 1" />
+	<robot type="thymio2" port="33322" x="40" y="60" nodeId="2" id="T5" name="Test Net Inline 2" />
+	<process command="@ASEBASWITCH@ -p 33323 -n Network-Aesl-Inline tcp:localhost;33321 tcp:localhost;33322" />
+	<process command="@ASEBAHTTP@ --autorestart --http 3002 tcp:localhost;33323" />
+	<process command="curl --retry 3 --header Content-Type:&#9;application/octet-stream --data-ascii &lt;!DOCTYPE&#9;aesl-source&gt;&#9;&lt;network&gt;&#9;&lt;event&#9;size=&quot;1&quot;&#9;name=&quot;alive&quot;/&gt;&#9;&lt;node&#9;nodeId=&quot;1&quot;&#9;name=&quot;thymio-II&quot;&gt;&#9;timer.period=[3000,0]&#9;onevent&#9;timer0&#9;emit&#9;alive([1])&#9;&lt;/node&gt;&#9;&lt;/network&gt;&#9; -X PUT http://127.0.0.1:3002/nodes/1" />
+	<process command="curl --retry 3 --header Content-Type:&#9;application/octet-stream --data-ascii &lt;!DOCTYPE&#9;aesl-source&gt;&#9;&lt;network&gt;&#9;&lt;event&#9;size=&quot;1&quot;&#9;name=&quot;alive&quot;/&gt;&#9;&lt;node&#9;nodeId=&quot;1&quot;&#9;name=&quot;thymio-II&quot;&gt;&#9;timer.period=[3000,0]&#9;onevent&#9;timer0&#9;emit&#9;alive([2])&#9;&lt;/node&gt;&#9;&lt;/network&gt;&#9; -X PUT http://127.0.0.1:3002/nodes/2" />
+</aseba-playground>

--- a/tests/e2e-playground/test-2-networks.playground
+++ b/tests/e2e-playground/test-2-networks.playground
@@ -1,0 +1,38 @@
+<!DOCTYPE aseba-playground>
+<!-- Aseba playground for testing creation of multi-node networks. -->
+<!-- 1. Solo node with a program loaded from an Aesl file -->
+<!-- 2. Two-node network with separate programs loaded from an Aesl file -->
+<!-- 3. Two-node network with separate programs specified from an inlined Aesl network -->
+
+<!-- Test 2: Load programs declared in a <networks> tag using Playground itself -->
+<!-- The test succeeds if the nodes in the three networks emit an alive event every 3 seconds -->
+
+<aseba-playground>
+	<world w="60" h="80" />
+
+	<robot type="thymio2" port="33301" x="20" y="20" nodeId="1" id="T1" name="Test Solo Single" />
+
+	<robot type="thymio2" port="33311" x="20" y="40" nodeId="1" id="T2" name="Test Net File 1" />
+	<robot type="thymio2" port="33312" x="40" y="40" nodeId="2" id="T3" name="Test Net File 2" />
+
+	<robot type="thymio2" port="33321" x="20" y="60" nodeId="1" id="T4" name="Test Net Inline 1" />
+	<robot type="thymio2" port="33322" x="40" y="60" nodeId="2" id="T5" name="Test Net Inline 2" />
+
+	<networks>
+		<network name="Solo-Aesl-File" robots="T1" aeslFile="beacon-solo.aesl" />
+		<network name="Network-Aesl-File" robots="T2 T3" aeslFile="beacon-net.aesl" />
+		<network name="Network-Aesl-Inline" robots="T4 T5">
+			<event size="1" name="alive"/>
+			<node nodeId="1" name="thymio-II">
+			timer.period=[3000,0]
+			onevent timer0
+			emit alive([1])
+			</node>
+			<node nodeId="2" name="thymio-II">
+			timer.period=[3000,0]
+			onevent timer0
+			emit alive([2])
+			</node>
+		</network>
+	</networks>
+</aseba-playground>


### PR DESCRIPTION
This PR proposes end-to-end testing for multi-node networks within a Playground. It uses CMake to build testing scripts that refer to the correct executables. A test for a proposed extension to the playground format is included.

The testing scenario comprises five simulated Thymio-II robots partitioned into three networks.

1. A solo node with a program loaded from an Aesl file
2. A two-node network with separate programs loaded from an external Aesl file 
3. A two-node network with separate programs specified from an Aesl network whose definition is inlined in the Playground

The programs are simple beacons, that broadcast an *alive* message with the id of the node evry three seconds.

Playground `test-1-processes.playground` illustrates how to build three networks in a five-node playground, using `<process>` tags to start **asebaswitch**, **asebamassloader**, and **asebahttp** (for inlined Aesl programs).

Playground `test-2-networks.playground` illustrates a proposed extension to the XML definition, suggested in https://github.com/aseba-community/aseba/issues/624#issuecomment-362414283. Since this test isn't implemented, the CMakeLists.txt declares that this test is expected to fail.