### PR TITLE
Do not copy Qt until install

### DIFF
--- a/CMakeModules/deployqt.cmake
+++ b/CMakeModules/deployqt.cmake
@@ -33,15 +33,15 @@ find_program(WINDEPLOYQT_EXECUTABLE windeployqt.exe HINTS "${_qt_bin_dir}")
 # build and install the Qt runtime to the specified directory
 function(windeployqt target directory)
 
-    # Run windeployqt immediately after build
-    add_custom_command(TARGET ${target} POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E
-            env PATH="${_qt_bin_dir}" "${WINDEPLOYQT_EXECUTABLE}"
-                --no-compiler-runtime
-                --plugindir plugins
-                \"$<TARGET_FILE:${target}>\"
-        COMMENT "Deploying Qt..."
-    )
+#     # Run windeployqt immediately after build
+#     execute_process(TARGET ${target} POST_BUILD
+#         COMMAND "${CMAKE_COMMAND}" -E
+#             env PATH="${_qt_bin_dir}" "${WINDEPLOYQT_EXECUTABLE}"
+#                 --no-compiler-runtime
+#                 --plugindir plugins
+#                 \"$<TARGET_FILE:${target}>\"
+#         COMMENT "Deploying Qt..."
+#     )
 
     # install(CODE ...) doesn't support generator expressions, but
     # file(GENERATE ...) does - store the path in a file


### PR DESCRIPTION
On windows, doing though leads to concurrent file access
wich leads to a build failure.