### PR TITLE
WIP: Python 3 compatibility, fix #888

### DIFF
--- a/CMakeModules/sign.py
+++ b/CMakeModules/sign.py
@@ -1,28 +1,27 @@
 #!/usr/bin/python
 
-from subprocess import call
-import sys
 import os
 import shutil
+import sys
+from subprocess import call
 
 timestamp_server = "http://timestamp.digicert.com"
 url = "http://http://www.mobsya.org/"
 
 binary = sys.argv[1] if len(sys.argv) > 1 else None
-exists = binary != None and os.path.isfile(binary)
+exists = binary is not None and os.path.isfile(binary)
 
-scp  = os.environ.get("SIGNTOOL_SCP")
-key  = os.environ.get("SIGNTOOL_KEY")
-pfx  = os.environ.get("SIGNTOOL_PFX")
-pss  = os.environ.get("SIGNTOOL_PASSPHRASE")
+scp = os.environ.get("SIGNTOOL_SCP")
+key = os.environ.get("SIGNTOOL_KEY")
+pfx = os.environ.get("SIGNTOOL_PFX")
+pss = os.environ.get("SIGNTOOL_PASSPHRASE")
 
 if binary and not exists:
-	print("File {} does not exist".format(binary))
-	exit(1)
+    print("File {} does not exist".format(binary))
+    exit(1)
 
 elif not exists or not ((scp and key) or (pss and pfx)):
-	print(
-"""
+    print("""
 Usage {} <binary>
 
 Sign a binary with either osslsigncode or signcode(win32)
@@ -36,61 +35,60 @@ To sign with signtool, the following environnement variables must be defined
 
  * SIGNTOOL_PFX : Must be the path of a valid pfx file
  * SIGNTOOL_PASSPHRASE : Passphrase of the PFX file
-"""
-)
-	exit(1)
+""")
+    exit(1)
 
 _, ext = os.path.splitext(binary)
 if ext[1:] not in ['exe', 'dll']:
-	print("Not a signable file, ignoring")
-	exit(0)
+    print("Not a signable file, ignoring")
+    exit(0)
 
-
-#signtool ( native windows)
+# signtool ( native windows)
 if pss and pfx:
-	print("Signing with signtool")
-	if not os.path.isfile(pfx):
-		print("signtool: No PFX File Found ({} does not exist)".format(pfx))
-		exit(1)
-	ret = call([
-		"signtool", "sign"
-		"/f"   , pfx,
-		"/p"   , pss,
-		"/fd"  , "sha256",
-		"/td"  , "sha256",
-		"/du"  , url,
-		"/tr"  , timestamp_server,
-		"/as"  , binary,
-	])
-	if ret != 0:
-		print("signtool failed (ret {})".format(ret))
-	exit(ret)
+    print("Signing with signtool")
+    if not os.path.isfile(pfx):
+        print("signtool: No PFX File Found ({} does not exist)".format(pfx))
+        exit(1)
+    ret = call([
+        "signtool",
+        "sign"
+        "/f",
+        pfx,
+        "/p",
+        pss,
+        "/fd",
+        "sha256",
+        "/td",
+        "sha256",
+        "/du",
+        url,
+        "/tr",
+        timestamp_server,
+        "/as",
+        binary,
+    ])
+    if ret != 0:
+        print("signtool failed (ret {})".format(ret))
+    exit(ret)
 
-#signcode
+# signcode
 if scp and key:
-	print("Signing with osslsigncode")
-	if not os.path.isfile(scp):
-		print("signcode: No SCP File Found ({} does not exist)".format(scp))
-		exit(1)
-	if not os.path.isfile(key):
-		print("signcode: No KEY File Found ({} does not exist)".format(key))
-		exit(1)
+    print("Signing with osslsigncode")
+    if not os.path.isfile(scp):
+        print("signcode: No SCP File Found ({} does not exist)".format(scp))
+        exit(1)
+    if not os.path.isfile(key):
+        print("signcode: No KEY File Found ({} does not exist)".format(key))
+        exit(1)
 
-	out = binary+".signed"
+    out = binary + ".signed"
 
-	ret = call([
-		"osslsigncode",
-		"-spc", scp,
-		"-key", key,
-		"-h"  , "sha256",
-		"-i"  , url,
-		"-t"  , timestamp_server,
-		"-in" , binary,
-		"-out", out
-	])
-	if(os.path.isfile(out)):
-		shutil.move(out, binary)
-	if ret != 0:
-		print("osslsigncode failed (ret {})".format(ret))
-	exit(ret)
-
+    ret = call([
+        "osslsigncode", "-spc", scp, "-key", key, "-h", "sha256", "-i", url, "-t", timestamp_server, "-in", binary,
+        "-out", out
+    ])
+    if (os.path.isfile(out)):
+        shutil.move(out, binary)
+    if ret != 0:
+        print("osslsigncode failed (ret {})".format(ret))
+    exit(ret)

--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -20,7 +20,8 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-import subprocess, os
+import subprocess
+
 subprocess.call('cd ../doxygen; doxygen', shell=True)
 
 # -- General configuration ------------------------------------------------
@@ -32,10 +33,12 @@ subprocess.call('cd ../doxygen; doxygen', shell=True)
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.imgmath',
-    'sphinx.ext.githubpages', 'sphinx.ext.intersphinx', 'sphinx.ext.imgmath', 'sphinx.ext.todo', 'breathe']
+extensions = [
+    'sphinx.ext.imgmath', 'sphinx.ext.githubpages', 'sphinx.ext.intersphinx', 'sphinx.ext.imgmath', 'sphinx.ext.todo',
+    'breathe'
+]
 
-breathe_projects = { "aseba": "../doxygen/doc/xml" }
+breathe_projects = {"aseba": "../doxygen/doc/xml"}
 breathe_default_project = "aseba"
 
 # Add any paths that contain templates here, relative to this directory.
@@ -82,7 +85,6 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
-
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -90,10 +92,12 @@ todo_include_todos = False
 #
 html_theme = 'sphinx_rtd_theme'
 
+
 # Use a style similar to the Linux Kernel documentation. as
 # it is more usable than the default RTD theme
 def setup(app):
     app.add_stylesheet('theme_overrides.css')
+
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -111,17 +115,12 @@ html_static_path = ['_static']
 #
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    '**': [
-    ]
-}
-
+html_sidebars = {'**': []}
 
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Asebadoc'
-
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -147,20 +146,14 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Aseba.tex', u'Aseba Documentation',
-     u'Stéphane Magnenat and other contributors', 'manual'),
+    (master_doc, 'Aseba.tex', u'Aseba Documentation', u'Stéphane Magnenat and other contributors', 'manual'),
 ]
-
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'aseba', u'Aseba Documentation',
-     [author], 1)
-]
-
+man_pages = [(master_doc, 'aseba', u'Aseba Documentation', [author], 1)]
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -168,10 +161,6 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Aseba', u'Aseba Documentation',
-     author, 'Aseba', 'A set of tools which allow beginners to program robots easily and efficiently.',
-     'Miscellaneous'),
+    (master_doc, 'Aseba', u'Aseba Documentation', author, 'Aseba',
+     'A set of tools which allow beginners to program robots easily and efficiently.', 'Miscellaneous'),
 ]
-
-
-

--- a/examples/clients/python-dbus/aseba.py
+++ b/examples/clients/python-dbus/aseba.py
@@ -1,6 +1,14 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
+import time
+
+import dbus
+import gobject
+from dbus.mainloop.glib import DBusGMainLoop
+from six import string_types
 """
 A Python binding for Aseba that relies on DBus for IPC.
 
@@ -27,26 +35,24 @@ may be a convenient way to make sure the connection is in good state.
 
 __author__ = "Séverin Lemaignan, Stéphane Magnenat"
 
-import dbus
-import time
-
-from dbus.mainloop.glib import DBusGMainLoop
-import gobject
 # required to prevent the glib main loop to interfere with Python threads
 gobject.threads_init()
 dbus.mainloop.glib.threads_init()
 
+
 class AsebaException(Exception):
     def __init__(self, value):
         self.value = value
+
     def __str__(self):
         return repr(self.value)
 
+
 class Aseba(object):
 
-    NB_EVTS_FREQ = 10 # nb of events to be received before computing frequency
+    NB_EVTS_FREQ = 10  # nb of events to be received before computing frequency
 
-    def __init__(self, system_bus = False, dummy = False):
+    def __init__(self, system_bus=False, dummy=False):
         self.dummy = dummy
 
         self.callbacks = {}
@@ -56,7 +62,7 @@ class Aseba(object):
 
         if not dummy:
             DBusGMainLoop(set_as_default=True)
-            # init 
+            # init
             if system_bus:
                 self.bus = dbus.SystemBus()
             else:
@@ -64,18 +70,14 @@ class Aseba(object):
 
             try:
                 self.network = dbus.Interface(
-                        self.bus.get_object('ch.epfl.mobots.Aseba', '/'), 
-                        dbus_interface='ch.epfl.mobots.AsebaNetwork')
+                    self.bus.get_object('ch.epfl.mobots.Aseba', '/'), dbus_interface='ch.epfl.mobots.AsebaNetwork')
             except dbus.exceptions.DBusException:
-                raise AsebaException("Can not connect to Aseba DBus services! "
-                                     "Is asebamedulla running?")
-
+                raise AsebaException("Can not connect to Aseba DBus services! " "Is asebamedulla running?")
 
             # Configure event management
             eventfilter = self.network.CreateEventFilter()
             self.events = dbus.Interface(
-                        self.bus.get_object('ch.epfl.mobots.Aseba', eventfilter), 
-                        dbus_interface='ch.epfl.mobots.EventFilter')
+                self.bus.get_object('ch.epfl.mobots.Aseba', eventfilter), dbus_interface='ch.epfl.mobots.EventFilter')
             self.dispatch_handler = self.events.connect_to_signal('Event', self._dispatch_events)
 
     def clear_events(self):
@@ -83,8 +85,8 @@ class Aseba(object):
         """
         try:
             introspect = dbus.Interface(
-                        self.bus.get_object('ch.epfl.mobots.Aseba', "/events_filters"), 
-                        dbus_interface=dbus.INTROSPECTABLE_IFACE)
+                self.bus.get_object('ch.epfl.mobots.Aseba', "/events_filters"),
+                dbus_interface=dbus.INTROSPECTABLE_IFACE)
             interface = introspect.Introspect()
         except dbus.exceptions.DBusException:
             # /events_filters not yet created -> no events to delete
@@ -95,8 +97,8 @@ class Aseba(object):
         for n in root.iter("node"):
             if 'name' in n.attrib:
                 evtfilter = dbus.Interface(
-                        self.bus.get_object('ch.epfl.mobots.Aseba', "/events_filters/%s" % n.attrib['name']), 
-                        dbus_interface='ch.epfl.mobots.EventFilter')
+                    self.bus.get_object('ch.epfl.mobots.Aseba', "/events_filters/%s" % n.attrib['name']),
+                    dbus_interface='ch.epfl.mobots.EventFilter')
                 evtfilter.Free()
 
     def __enter__(self):
@@ -122,60 +124,59 @@ class Aseba(object):
         pass
 
     def dbus_error(self, e):
-        assert(not self.dummy)
+        assert (not self.dummy)
 
         # there was an error on D-Bus, stop loop
         self.close()
         raise Exception('dbus error: %s' % str(e))
 
     def get_nodes_list(self):
-        if self.dummy: return []
+        if self.dummy:
+            return []
 
         dbus_array = self.network.GetNodesList()
         size = len(dbus_array)
-        return [str(dbus_array[x]) for x in range(0,size)]
+        return [str(dbus_array[x]) for x in range(0, size)]
 
     def set(self, node, var, value):
-        if self.dummy: return
+        if self.dummy:
+            return
         self.network.SetVariable(node, var, value)
 
     def get(self, node, var):
-        if self.dummy: return [0] * 10
+        if self.dummy:
+            return [0] * 10
         dbus_array = self.network.GetVariable(node, var)
         size = len(dbus_array)
         if (size == 1):
             return int(dbus_array[0])
         else:
-            return [int(dbus_array[x]) for x in range(0,size)]
+            return [int(dbus_array[x]) for x in range(0, size)]
 
     def send_event(self, event_id, event_args):
 
-        if isinstance(event_id, basestring):
+        if isinstance(event_id, string_types):
             return self.send_event_name(event_id, event_args)
 
-        if self.dummy: return
+        if self.dummy:
+            return
 
         # events are sent asynchronously
-        self.network.SendEvent(event_id, 
-                               event_args,
-                               reply_handler=self.dbus_reply,
-                               error_handler=self.dbus_error)
-
+        self.network.SendEvent(event_id, event_args, reply_handler=self.dbus_reply, error_handler=self.dbus_error)
 
     def send_event_name(self, event_name, event_args):
-        if self.dummy: return
+        if self.dummy:
+            return
 
         # events are sent asynchronously
-        self.network.SendEventName(event_name, 
-                                   event_args,
-                                   reply_handler=self.dbus_reply,
-                                   error_handler=self.dbus_error)
-
+        self.network.SendEventName(
+            event_name, event_args, reply_handler=self.dbus_reply, error_handler=self.dbus_error)
 
     def load_scripts(self, path):
         """ Loads a given Aseba script (aesl) on the Aseba network.
         """
-        if self.dummy: return
+        if self.dummy:
+            return
         self.network.LoadScripts(path)
 
     def _dispatch_events(self, *args):
@@ -207,24 +208,31 @@ class Aseba(object):
         :param event_id: the event name or the event numerical ID
         :param cb: the callback function that will be called with the content of the event as parameter
         """
-        if self.dummy: return
+        if self.dummy:
+            return
 
         self.callbacks[event_id] = cb
         self._events_last_evt[event_id] = time.time()
         self._events_periods[event_id] = []
         self.events_freq[event_id] = 0.
 
-        if isinstance(event_id, basestring):
+        if isinstance(event_id, string_types):
             self.events.ListenEventName(event_id)
         else:
             self.events.ListenEvent(event_id)
+
 
 # *** TEST ***
 if __name__ == '__main__':
     from optparse import OptionParser
     parser = OptionParser()
-    parser.add_option("-s", "--system", action="store_true", dest="system", default=False,
-            help="use the system bus instead of the session bus")
+    parser.add_option(
+        "-s",
+        "--system",
+        action="store_true",
+        dest="system",
+        default=False,
+        help="use the system bus instead of the session bus")
 
     (options, args) = parser.parse_args()
 
@@ -236,11 +244,10 @@ if __name__ == '__main__':
         # 'timer0' is the name of the Aseba event you want to subscribe to.
         aseba.on_event("timer0", my_callback)
 
-        print "List of nodes: ", aseba.get_nodes_list()
+        print("List of nodes: ", aseba.get_nodes_list())
 
         aseba.set("thymio-II", "event.source", [1])
         aseba.send_event(0, [])
 
-        print "Get variable temperature: ", aseba.get("thymio-II", "temperature")
-        print "Get array acc: ", aseba.get("thymio-II", "acc")
-
+        print("Get variable temperature: ", aseba.get("thymio-II", "temperature"))
+        print("Get array acc: ", aseba.get("thymio-II", "acc"))

--- a/examples/clients/python-dbus/setup.py
+++ b/examples/clients/python-dbus/setup.py
@@ -1,14 +1,14 @@
- #!/usr/bin/env python
- # -*- coding: utf-8 -*-
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-import os
 from distutils.core import setup
 
-setup(name='aseba',
-      version='1.0',
-      license='LGPL-v3',
-      description='A DBus-based Python binding for Aseba',
-      author='Séverin Lemaignan, Stéphane Magnenat',
-      author_email='severin.lemaignan@epfl.ch',
-      py_modules=['aseba'],
-      )
+setup(
+    name='aseba',
+    version='1.0',
+    license='LGPL-v3',
+    description='A DBus-based Python binding for Aseba',
+    author='Séverin Lemaignan, Stéphane Magnenat',
+    author_email='severin.lemaignan@epfl.ch',
+    py_modules=['aseba'],
+)

--- a/maintainer/authors/01_update_author_list.py
+++ b/maintainer/authors/01_update_author_list.py
@@ -19,8 +19,10 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import os.path
-import re
+import sys
 
 SCRIPT_DIRECTORY = sys.path[0]
 
@@ -28,8 +30,7 @@ top_level_path = os.path.join(SCRIPT_DIRECTORY, "..", "..")
 authors_source_file = os.path.join(top_level_path, "authors.txt")
 authors_dest_file = os.path.join(top_level_path, "aseba/common/authors.h")
 
-authors_file_head = \
-"""\
+authors_file_head = """
 #ifndef __ASEBA_AUTHORS_H
 #define __ASEBA_AUTHORS_H
 
@@ -38,38 +39,36 @@ authors_file_head = \
 
 namespace Aseba
 {
-	struct AuthorInfo
-	{
-		using Tags = std::set<std::string>;
+    struct AuthorInfo
+    {
+        using Tags = std::set<std::string>;
 
-		std::string name;
-		std::string email;
-		std::string web;
-		std::string role;
-		Tags tags;
-	};
-	using AuthorInfos = std::vector<AuthorInfo>;
+        std::string name;
+        std::string email;
+        std::string web;
+        std::string role;
+        Tags tags;
+    };
+    using AuthorInfos = std::vector<AuthorInfo>;
 
-	struct InstitutionInfo
-	{
-		std::string name;
-		std::string web;
-	};
-	using InstitutionInfos = std::vector<InstitutionInfo>;
+    struct InstitutionInfo
+    {
+        std::string name;
+        std::string web;
+    };
+    using InstitutionInfos = std::vector<InstitutionInfo>;
 
-	static const AuthorInfos authorList = {
+    static const AuthorInfos authorList = {
 """
 
-authors_file_contrib_step = \
-"""\
-	};
+authors_file_contrib_step = """
+    };
 
-	static const AuthorInfos thankToList = {
+    static const AuthorInfos thankToList = {
 """
 
-authors_file_tail = \
-"""\
-	};
+authors_file_tail = """
+    };
 } // namespace Aseba
 
 #endif // __ASEBA_AUTHORS_H
@@ -81,66 +80,66 @@ author = None
 authorLine = -1
 currentSection = AUTHORS
 with open(authors_dest_file, 'wb') as f:
-	f.write(authors_file_head)
-	for line in open(authors_source_file):
-		# strip newlines
-		line = line.strip('\n\r')
-		# switch sections
-		if line == '# Contributors':
-			currentSection = CONTRIBUTORS
-			f.write(authors_file_contrib_step)
-		elif line == '# Institutions':
-			currentSection = CONTRIBUTORS
-		# if first author line
-		if len(line) > 2 and line[0:2] == '*\t':
-			authorLine = 0
-			line = line[2:]
-		# otherwise only keep tabbed content
-		elif len(line) != 0 and line[0] == '\t':
-			line = line[1:]
-		else:
-			continue
-		# strip tabs and spaces
-		line = line.strip(' \t')
-		# if first line
-		if authorLine == 0:
-			author = {}
-			nameLine = line.split('<')
-			if len(nameLine) < 2:
-				author["name"] = line.split('[')[0].strip(' \t\n\r')
-			else:
-				name, rest = nameLine
-				if name[0] == '[':
-					name, web = name.split('(')
-					author["name"] = name.strip(' \t\n\r[]')
-					author["web"] = web.strip(' \t\n\r()')
-				else:
-					author["name"] = name.strip(' \t\n\r')
-				if '>' in rest:
-					email = rest.split('>')[0]
-					author["email"] = email.strip(' \t\n\r')
-		elif authorLine == 1:
-			author["role"] = line
-			pass
-		elif authorLine == 2:
-			line = line[len('contributed to: '):]
-			tags = line.split(', ')
-			author["tags"] = tags
-			if currentSection == AUTHORS:
-				print 'Adding author ' + author["name"]
-			else:
-				print 'Adding contributor ' + author["name"]
-			f.write('		{\n')
-			f.write('			u8"' + author.get("name","") + '",\n')
-			f.write('			u8"' + author.get("email","") + '",\n')
-			f.write('			u8"' + author.get("web","") + '",\n')
-			f.write('			u8"' + author.get("role","") + '",\n')
-			f.write('			{ ')
-			for tag in author.get("tags",[]):
-				f.write('u8"' + tag + '", ')
-			f.write('}\n')
-			f.write('		},\n')
-		else:
-			continue
-		authorLine += 1
-	f.write(authors_file_tail)
+    f.write(authors_file_head)
+    for line in open(authors_source_file):
+        # strip newlines
+        line = line.strip('\n\r')
+        # switch sections
+        if line == '# Contributors':
+            currentSection = CONTRIBUTORS
+            f.write(authors_file_contrib_step)
+        elif line == '# Institutions':
+            currentSection = CONTRIBUTORS
+        # if first author line
+        if len(line) > 2 and line[0:2] == '*\t':
+            authorLine = 0
+            line = line[2:]
+        # otherwise only keep tabbed content
+        elif len(line) != 0 and line[0] == '\t':
+            line = line[1:]
+        else:
+            continue
+        # strip tabs and spaces
+        line = line.strip(' \t')
+        # if first line
+        if authorLine == 0:
+            author = {}
+            nameLine = line.split('<')
+            if len(nameLine) < 2:
+                author["name"] = line.split('[')[0].strip(' \t\n\r')
+            else:
+                name, rest = nameLine
+                if name[0] == '[':
+                    name, web = name.split('(')
+                    author["name"] = name.strip(' \t\n\r[]')
+                    author["web"] = web.strip(' \t\n\r()')
+                else:
+                    author["name"] = name.strip(' \t\n\r')
+                if '>' in rest:
+                    email = rest.split('>')[0]
+                    author["email"] = email.strip(' \t\n\r')
+        elif authorLine == 1:
+            author["role"] = line
+            pass
+        elif authorLine == 2:
+            line = line[len('contributed to: '):]
+            tags = line.split(', ')
+            author["tags"] = tags
+            if currentSection == AUTHORS:
+                print('Adding author ' + author["name"])
+            else:
+                print('Adding contributor ' + author["name"])
+            f.write('        {\n')
+            f.write('            u8"' + author.get("name", "") + '",\n')
+            f.write('            u8"' + author.get("email", "") + '",\n')
+            f.write('            u8"' + author.get("web", "") + '",\n')
+            f.write('            u8"' + author.get("role", "") + '",\n')
+            f.write('            { ')
+            for tag in author.get("tags", []):
+                f.write('u8"' + tag + '", ')
+            f.write('}\n')
+            f.write('        },\n')
+        else:
+            continue
+        authorLine += 1
+    f.write(authors_file_tail)

--- a/maintainer/translations/01_new_language.py
+++ b/maintainer/translations/01_new_language.py
@@ -19,15 +19,19 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import sys
+from __future__ import print_function
+
 import os
 import os.path
-import subprocess
-import shutil
 import re
+import shutil
+import sys
 
-from path import *
+from six import input
+
 import translation_tools
+
+from . import path
 
 # some tags inside the files to help us
 cpp_tag = re.compile(r"/\* insert translation here")
@@ -41,6 +45,7 @@ thymioupgrader_qrc_tag = studio_qrc_tag
 thymiownetconfig_qrc_tag = studio_qrc_tag
 qtabout_qrc_tag = studio_qrc_tag
 
+
 def insert_before_tag(input_file, output_file, tag_re, inserted_text):
     with open(input_file) as in_file:
         with open(output_file, "w") as out_file:
@@ -52,25 +57,25 @@ def insert_before_tag(input_file, output_file, tag_re, inserted_text):
                     out_file.write(inserted_text)
                 out_file.write(line)
     if not found:
-        print sys.stderr, "Tag not found in ", input_file
+        print("Tag not found in ", input_file, file=sys.stderr)
     return found
 
 
-print "*****"
-print "This will add a new language to the available translations."
-print "We need first a few information."
-print "*****"
-print ""
+print("*****")
+print("This will add a new language to the available translations.")
+print("We need first a few information.")
+print("*****")
+print("")
 
 translation_tools.init_commands()
 
-name_en = raw_input("\nLanguage name (in English): ")
-name = raw_input("Language name, as displayed to users (ex: Français): ")
-print "\n***"
-print "Hint: for a list a locales, you can look here: http://www.roseindia.net/tutorials/i18n/locales-list.shtml"
-print "***\n"
-code_lang = raw_input("Language code (ex: fr): ")
-code_region = raw_input("Region code, if any (ex: ch): ")
+name_en = input("\nLanguage name (in English): ")
+name = input("Language name, as displayed to users (ex: Français): ")
+print("\n***")
+print("Hint: for a list a locales, you can look here: http://www.roseindia.net/tutorials/i18n/locales-list.shtml")
+print("***\n")
+code_lang = input("Language code (ex: fr): ")
+code_region = input("Region code, if any (ex: ch): ")
 
 if code_region == '':
     code = code_lang
@@ -78,144 +83,146 @@ else:
     code = code_lang + "_" + code_region
 
 wikidot_url = ""
-if raw_input("\nIs the wikidot user manual also translated and to be added to the offline help? [y/N] ").lower() == 'y':
-    wikidot_url = "https://aseba.wikidot.com/{}:asebausermanual".format(code)   # should be good
-    temp = raw_input("What is its url? [{}] ".format(wikidot_url))
+if input("\nIs the wikidot user manual also translated and to be added to the offline help? [y/N] ").lower() == 'y':
+    wikidot_url = "https://aseba.wikidot.com/{}:asebausermanual".format(code)  # should be good
+    temp = input("What is its url? [{}] ".format(wikidot_url))
     if temp:
         wikidot_url = temp
 
-if raw_input("\nAre you happy with your input? [y/N] ").lower() != 'y':
+if input("\nAre you happy with your input? [y/N] ").lower() != 'y':
     exit(2)
 
-print "Generating files...\n"
-os.chdir(studio_path)
+print("Generating files...\n")
+os.chdir(path.studio_path)
 
 # lupdate asebastudio_x.{ts,qm}
-translation_tools.do_lupdate("asebastudio", code, " ".join([studio_path, plugin_path, vpl_path]))
+translation_tools.do_lupdate("asebastudio", code, " ".join([path.studio_path, path.plugin_path, path.vpl_path]))
 
 # lupdate compiler_x.{ts,qm}
-translation_tools.do_lupdate("compiler", code, compiler_ts_path)
+translation_tools.do_lupdate("compiler", code, path.compiler_ts_path)
 
-os.chdir(challenge_path)
+os.chdir(path.challenge_path)
 # lupdate asebachallenge_x.{ts,qm}
-translation_tools.do_lupdate("asebachallenge", code, challenge_cpp)
+translation_tools.do_lupdate("asebachallenge", code, path.challenge_cpp)
 
-os.chdir(playground_path)
+os.chdir(path.playground_path)
 # lupdate asebaplayground_x.{ts,qm}
-translation_tools.do_lupdate("asebaplayground", code, playground_path)
+translation_tools.do_lupdate("asebaplayground", code, path.playground_path)
 
-os.chdir(thymioupgrader_path)
+os.chdir(path.thymioupgrader_path)
 # lupdate thymioupgrader_x.{ts,qm}
-translation_tools.do_lupdate("thymioupgrader", code, thymioupgrader_path)
+translation_tools.do_lupdate("thymioupgrader", code, path.thymioupgrader_path)
 
-os.chdir(thymiownetconfig_path)
+os.chdir(path.thymiownetconfig_path)
 # lupdate thymiownetconfig_x.{ts,qm}
-translation_tools.do_lupdate("thymiownetconfig", code, thymiownetconfig_path)
+translation_tools.do_lupdate("thymiownetconfig", code, path.thymiownetconfig_path)
 
-os.chdir(qtabout_path)
+os.chdir(path.qtabout_path)
 # lupdate qtabout_x.{ts,qm}
-translation_tools.do_lupdate("qtabout", code, qtabout_path)
+translation_tools.do_lupdate("qtabout", code, path.qtabout_path)
 
-
-print "Modifying source files...\n"
+print("Modifying source files...\n")
 
 # We have to update DashelTarget.cpp
-print "Updating DashelTarget.cpp..."
-os.chdir(studio_path)
+print("Updating DashelTarget.cpp...")
+os.chdir(path.studio_path)
 tmp_file = "DashelTarget.cpp.tmp"
-insert_before_tag(dashel_target, tmp_file, cpp_tag, """\t\tlanguageSelectionBox->addItem(QString::fromUtf8("{}"), "{}");\n""".format(name, code))
-os.remove(dashel_target)
-shutil.move(tmp_file, dashel_target)
-translation_tools.do_git_add(dashel_target)
-print "Done\n"
+insert_before_tag(path.dashel_target, tmp_file, cpp_tag,
+                  """\t\tlanguageSelectionBox->addItem(QString::fromUtf8("{}"), "{}");\n""".format(name, code))
+os.remove(path.dashel_target)
+shutil.move(tmp_file, path.dashel_target)
+translation_tools.do_git_add(path.dashel_target)
+print("Done\n")
 
 # We have to update asebastudio.qrc
-print "Updating asebastudio.qrc..."
+print("Updating asebastudio.qrc...")
 tmp_file1 = "asebastudio.qrc.tmp1"
 tmp_file2 = "asebastudio.qrc.tmp2"
-insert_before_tag(studio_qrc, tmp_file1, studio_qrc_tag, """\t<file>asebastudio_{}.qm</file>\n""".format(code))
+insert_before_tag(path.studio_qrc, tmp_file1, studio_qrc_tag, """\t<file>asebastudio_{}.qm</file>\n""".format(code))
 insert_before_tag(tmp_file1, tmp_file2, studio_qrc_compiler_tag, """\t<file>compiler_{}.qm</file>\n""".format(code))
 os.remove(tmp_file1)
-os.remove(studio_qrc)
-shutil.move(tmp_file2, studio_qrc)
-translation_tools.do_git_add(studio_qrc)
-print "Done\n"
+os.remove(path.studio_qrc)
+shutil.move(tmp_file2, path.studio_qrc)
+translation_tools.do_git_add(path.studio_qrc)
+print("Done\n")
 
 # We have to update challenge.cpp
-print "Updating challenge.cpp..."
-os.chdir(challenge_path)
+print("Updating challenge.cpp...")
+os.chdir(path.challenge_path)
 tmp_file = "challenge.cpp.tmp"
-insert_before_tag(challenge_cpp, tmp_file, cpp_tag, """\tlanguageSelectionBox->addItem(QString::fromUtf8("{}"), "{}");\n""".format(name, code))
-os.remove(challenge_cpp)
-shutil.move(tmp_file, challenge_cpp)
-translation_tools.do_git_add(challenge_cpp)
-print "Done\n"
+insert_before_tag(path.challenge_cpp, tmp_file, cpp_tag,
+                  """\tlanguageSelectionBox->addItem(QString::fromUtf8("{}"), "{}");\n""".format(name, code))
+os.remove(path.challenge_cpp)
+shutil.move(tmp_file, path.challenge_cpp)
+translation_tools.do_git_add(path.challenge_cpp)
+print("Done\n")
 
 # We have to update challenge-textures.qrc
-print "Updating challenge-textures.qrc..."
+print("Updating challenge-textures.qrc...")
 tmp_file = "challenge-textures.qrc.tmp"
-insert_before_tag(challenge_qrc, tmp_file, challenge_qrc_tag, """\t<file>asebachallenge_{}.qm</file>\n""".format(code))
-os.remove(challenge_qrc)
-shutil.move(tmp_file, challenge_qrc)
-translation_tools.do_git_add(challenge_qrc)
-print "Done\n"
+insert_before_tag(path.challenge_qrc, tmp_file, challenge_qrc_tag,
+                  """\t<file>asebachallenge_{}.qm</file>\n""".format(code))
+os.remove(path.challenge_qrc)
+shutil.move(tmp_file, path.challenge_qrc)
+translation_tools.do_git_add(path.challenge_qrc)
+print("Done\n")
 
 # We have to update asebaplayground.qrc
-print "Updating asebaplayground.qrc..."
-os.chdir(playground_path)
+print("Updating asebaplayground.qrc...")
+os.chdir(path.playground_path)
 tmp_file = "asebaplayground.qrc.tmp"
-insert_before_tag(playground_qrc, tmp_file, playground_qrc_tag, """\t<file>asebaplayground_{}.qm</file>\n""".format(code))
-os.remove(playground_qrc)
-shutil.move(tmp_file, playground_qrc)
-translation_tools.do_git_add(playground_qrc)
-print "Done\n"
+insert_before_tag(path.playground_qrc, tmp_file, playground_qrc_tag,
+                  """\t<file>asebaplayground_{}.qm</file>\n""".format(code))
+os.remove(path.playground_qrc)
+shutil.move(tmp_file, path.playground_qrc)
+translation_tools.do_git_add(path.playground_qrc)
+print("Done\n")
 
 # We have to update thymioupgrader.qrc
-print "Updating thymioupgrader.qrc..."
-os.chdir(thymioupgrader_path)
+print("Updating thymioupgrader.qrc...")
+os.chdir(path.thymioupgrader_path)
 tmp_file = "thymioupgrader.qrc.tmp"
-insert_before_tag(thymioupgrader_qrc, tmp_file, thymioupgrader_qrc_tag, """\t<file>thymioupgrader_{}.qm</file>\n""".format(code))
-os.remove(thymioupgrader_qrc)
-shutil.move(tmp_file, thymioupgrader_qrc)
-translation_tools.do_git_add(thymioupgrader_qrc)
-print "Done\n"
+insert_before_tag(path.thymioupgrader_qrc, tmp_file, thymioupgrader_qrc_tag,
+                  """\t<file>thymioupgrader_{}.qm</file>\n""".format(code))
+os.remove(path.thymioupgrader_qrc)
+shutil.move(tmp_file, path.thymioupgrader_qrc)
+translation_tools.do_git_add(path.thymioupgrader_qrc)
+print("Done\n")
 
 # We have to update thymiownetconfig.qrc
-print "Updating thymiownetconfig.qrc..."
-os.chdir(thymiownetconfig_path)
+print("Updating thymiownetconfig.qrc...")
+os.chdir(path.thymiownetconfig_path)
 tmp_file = "thymiownetconfig.qrc.tmp"
-insert_before_tag(thymiownetconfig_qrc, tmp_file, thymiownetconfig_qrc_tag, """\t<file>thymiownetconfig_{}.qm</file>\n""".format(code))
-os.remove(thymiownetconfig_qrc)
-shutil.move(tmp_file, thymiownetconfig_qrc)
-translation_tools.do_git_add(thymiownetconfig_qrc)
-print "Done\n"
+insert_before_tag(path.thymiownetconfig_qrc, tmp_file, thymiownetconfig_qrc_tag,
+                  """\t<file>thymiownetconfig_{}.qm</file>\n""".format(code))
+os.remove(path.thymiownetconfig_qrc)
+shutil.move(tmp_file, path.thymiownetconfig_qrc)
+translation_tools.do_git_add(path.thymiownetconfig_qrc)
+print("Done\n")
 
 # We have to update asebaqtabout.qrc
-print "Updating asebaqtabout.qrc..."
-os.chdir(qtabout_path)
+print("Updating asebaqtabout.qrc...")
+os.chdir(path.qtabout_path)
 tmp_file = "asebaqtabout.qrc.tmp"
-insert_before_tag(qtabout_qrc, tmp_file, qtabout_qrc_tag, """\t<file>qtabout_{}.qm</file>\n""".format(code))
-os.remove(qtabout_qrc)
-shutil.move(tmp_file, qtabout_qrc)
-translation_tools.do_git_add(qtabout_qrc)
-print "Done\n"
-
+insert_before_tag(path.qtabout_qrc, tmp_file, qtabout_qrc_tag, """\t<file>qtabout_{}.qm</file>\n""".format(code))
+os.remove(path.qtabout_qrc)
+shutil.move(tmp_file, path.qtabout_qrc)
+translation_tools.do_git_add(path.qtabout_qrc)
+print("Done\n")
 
 # Update updatedoc.py, if asked by the user
 if wikidot_url:
-    os.chdir(updatedoc_path)
-    print "Updating updatedoc.py"
+    os.chdir(path.updatedoc_path)
+    print("Updating updatedoc.py")
     tmp_file = "updatedoc.py.tmp"
-    insert_before_tag(updatedoc, tmp_file, updatedoc_tag, """                '{}':'{}',\n""".format(code, wikidot_url))
-    os.remove(updatedoc)
-    shutil.move(tmp_file, updatedoc)
-    translation_tools.do_git_add(updatedoc)
-    print "Done\n"
+    insert_before_tag(path.updatedoc, tmp_file, updatedoc_tag, """                '{}':'{}',\n""".format(
+        code, wikidot_url))
+    os.remove(path.updatedoc)
+    shutil.move(tmp_file, path.updatedoc)
+    translation_tools.do_git_add(path.updatedoc)
+    print("Done\n")
 
-
-print "We are done! Now edit the .ts files with Qt Linguist"
-print "Finally, do not forget to commit the .ts files."
-print "Have fun :-)\n"
-print "*****\n"
-
-
+print("We are done! Now edit the .ts files with Qt Linguist")
+print("Finally, do not forget to commit the .ts files.")
+print("Have fun :-)\n")
+print("*****\n")

--- a/maintainer/translations/02_sync_compiler_translation.py
+++ b/maintainer/translations/02_sync_compiler_translation.py
@@ -18,21 +18,19 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 # System lib
-import os
-import os.path
+import re
 import sys
 from string import Template
-import re
-import subprocess
 
-from path import *
+from . import path
 
 comment_regexp = re.compile(r'\A\s*// (.*)')
 error_regexp = re.compile(r'error_map\[(.*?)\]\s*=\s*L"(.*?)";')
 
-output_code_file = \
-"""
+output_code_file = """
 #ifndef __ERRORS_H
 #define __ERRORS_H
 
@@ -46,63 +44,56 @@ to generate a new version, based on errors.cpp
 // define error codes
 namespace Aseba
 {
-	enum ErrorCode
-	{
-		// ${start_comment}
-		${id_0} = 0,
+    enum ErrorCode
+    {
+        // ${start_comment}
+        ${id_0} = 0,
 ${id_others}
-		ERROR_END
-	};
+        ERROR_END
+    };
 };
 
 #endif // __ERRORS_H
 """
 output_code_file_template = Template(output_code_file)
 
-output_qt_file = \
-"""
+output_qt_file = """
 #include "CompilerTranslator.h"
 #include "compiler/errors_code.h"
 
 namespace Aseba
 {
-	CompilerTranslator::CompilerTranslator()
-	{
+    CompilerTranslator::CompilerTranslator()
+    {
 
-	}
+    }
 
-	const std::wstring CompilerTranslator::translate(ErrorCode error)
-	{
-		QString msg;
+    const std::wstring CompilerTranslator::translate(ErrorCode error)
+    {
+        QString msg;
 
-		switch (error)
-		{
+        switch (error)
+        {
 ${elements}
-			default:
-				msg = tr("Unknown error");
-		}
+            default:
+                msg = tr("Unknown error");
+        }
 
-		return msg.toStdWString();
-	}
+        return msg.toStdWString();
+    }
 };
 """
 output_qt_file_template = Template(output_qt_file)
 
-output_qt_element = \
-"""
-			case ${error_id}:
-				msg = tr("${error_msg}");
-				break;
+output_qt_element = """
+            case ${error_id}:
+                msg = tr("${error_msg}");
+                break;
 """
 output_qt_element_template = Template(output_qt_element)
 
 # process input file
-print "Reading " + errors_cpp
-try:
-    fh = file(errors_cpp)
-except:
-    print >> sys.stderr, "Invalid file " + errors_cpp
-    exit(1)
+print("Reading " + path.errors_cpp)
 
 case_vector = ""
 count = 0
@@ -110,56 +101,56 @@ id_0 = None
 start_comment = ""
 id_others = ""
 
-print "Processing..."
-for line in fh:
-    # a comment?
-    match = comment_regexp.search(line)
-    if match:
-        # add it to the error codes file
-        if not id_0:
-            start_comment = match.group(1)
-        else:
-            id_others += "		// " + match.group(1) + "\n"
-        continue
+try:
+    with open(path.errors_cpp) as fh:
+        print("Processing...")
+        for line in fh:
+            # a comment?
+            match = comment_regexp.search(line)
+            if match:
+                # add it to the error codes file
+                if not id_0:
+                    start_comment = match.group(1)
+                else:
+                    id_others += "        // " + match.group(1) + "\n"
+                continue
 
-    match = error_regexp.search(line)
-    if match:
-        count = count + 1
-        code = match.group(1)
-        msg = match.group(2)
-        # error codes file
-        if not id_0:
-            id_0 = code
-        else:
-            id_others += "		" + code + ",\n"
-        # qt file
-        case_vector += output_qt_element_template.substitute(error_id=code, error_msg=msg)
+            match = error_regexp.search(line)
+            if match:
+                count = count + 1
+                code = match.group(1)
+                msg = match.group(2)
+                # error codes file
+                if not id_0:
+                    id_0 = code
+                else:
+                    id_others += "        " + code + ",\n"
+                # qt file
+                case_vector += output_qt_element_template.substitute(error_id=code, error_msg=msg)
+except IOError:
+    print("Invalid file " + path.errors_cpp, file=sys.stderr)
+    exit(1)
 
-fh.close()
-print "Found " + str(count) + " string(s)"
+print("Found " + str(count) + " string(s)")
 
 # writing errors_code.h
 result = output_code_file_template.substitute(start_comment=start_comment, id_0=id_0, id_others=id_others)
-print "Writing to " + errors_code_h
+print("Writing to " + path.errors_code_h)
 try:
-    fh = file(errors_code_h, 'w')
-except:
-    print >> sys.stderr, "Invalid file " + errors_code_h
+    with open(path.errors_code_h, 'w') as fh:
+        fh.write(result)
+except IOError:
+    print("Invalid file " + path.errors_code_h, file=sys.stderr)
     exit(1)
-
-fh.write(result)
-fh.close()
 
 # writing the qt file
 result = output_qt_file_template.substitute(elements=case_vector)
-print "Writing to " + compiler_ts_cpp
+print("Writing to " + path.compiler_ts_cpp)
 try:
-    fh = file(compiler_ts_cpp, 'w')
-except:
-    print >> sys.stderr, "Invalid file " + compiler_ts_cpp
+    with open(path.compiler_ts_cpp, 'w') as fh:
+        fh.write(result)
+except IOError:
+    print("Invalid file " + path.compiler_ts_cpp, file=sys.stderr)
     exit(1)
 
-fh.write(result)
-fh.close()
-print "Done!"
-
+print("Done!")

--- a/maintainer/translations/03_sync_all_translations.py
+++ b/maintainer/translations/03_sync_all_translations.py
@@ -19,35 +19,29 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import os.path
-import sys
-
-from path import *
+import path
 import translation_tools
 
 translation_tools.init_commands()
 
 # qtabout
-translation_tools.do_lupdate_all(qtabout_path, "qtabout", qtabout_path)
+translation_tools.do_lupdate_all(path.qtabout_path, "qtabout", path.qtabout_path)
 
 # asebastudio
-translation_tools.do_lupdate_all(studio_path, "asebastudio", " ".join([studio_path, plugin_path, vpl_path]))
+translation_tools.do_lupdate_all(path.studio_path, "asebastudio",
+                                 " ".join([path.studio_path, path.plugin_path, path.vpl_path]))
 
 # compiler
-translation_tools.do_lupdate_all(studio_path, "compiler", compiler_ts_path)
+translation_tools.do_lupdate_all(path.studio_path, "compiler", path.compiler_ts_path)
 
 # playground
-translation_tools.do_lupdate_all(playground_path, "asebaplayground", playground_path)
+translation_tools.do_lupdate_all(path.playground_path, "asebaplayground", path.playground_path)
 
 # challenge
-translation_tools.do_lupdate_all(challenge_path, "asebachallenge", challenge_cpp)
+translation_tools.do_lupdate_all(path.challenge_path, "asebachallenge", path.challenge_cpp)
 
 # upgrader
-translation_tools.do_lupdate_all(thymioupgrader_path, "thymioupgrader", thymioupgrader_path)
+translation_tools.do_lupdate_all(path.thymioupgrader_path, "thymioupgrader", path.thymioupgrader_path)
 
 # wnetconfig
-translation_tools.do_lupdate_all(thymiownetconfig_path, "thymiownetconfig", thymiownetconfig_path)
-
-
-
+translation_tools.do_lupdate_all(path.thymiownetconfig_path, "thymiownetconfig", path.thymiownetconfig_path)

--- a/maintainer/translations/04_translation_statistics.py
+++ b/maintainer/translations/04_translation_statistics.py
@@ -19,20 +19,23 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import sys
+from __future__ import print_function
+
+import glob
 import os
 import os.path
 import re
-import glob
+import sys
 
-from path import *
+from . import path
 
 translated_re = re.compile(r"""<translation>""")
 type_re = re.compile(r"""<translation type="(\w+?)">""")
 file_re = re.compile(r"""(\S+?)_(\w+).ts""")
 
+
 def file_statistics(f):
-#    print "\n*** {} ***\n".format(f)
+    #    print "\n*** {} ***\n".format(f)
     fd = open(f)
     stat = dict()
     stat['translated'] = 0
@@ -47,16 +50,17 @@ def file_statistics(f):
         # search untransalted / obsolete entries
         s = type_re.search(line)
         if s:
-            #print s.group(1)
+            # print s.group(1)
             state = s.group(1)
             if state == "unfinished":
                 stat['unfinished'] += 1
             elif state == "obsolete":
                 stat['obsolete'] += 1
             else:
-                print sys.stderr, "Unknown type: ", state
+                print("Unknown type: ", state, file=sys.stderr)
             continue
     return stat
+
 
 def directory_statistics(directory, stats):
     os.chdir(directory)
@@ -75,21 +79,21 @@ def directory_statistics(directory, stats):
 
     return stats
 
-print "*****"
-print "Statistics for translation files..."
-print "*****"
-print ""
+
+print("*****")
+print("Statistics for translation files...")
+print("*****")
+print("")
 
 stats = dict()
 
-stats = directory_statistics(studio_path, stats)
-stats = directory_statistics(challenge_path, stats)
+stats = directory_statistics(path.studio_path, stats)
+stats = directory_statistics(path.challenge_path, stats)
 
-
-print "       \t{:*^20}\t{:*^20}\t{:*^20}\t{:*^20}".format("Translated", "Total", "Percent", "Obsolete")
+print("       \t{:*^20}\t{:*^20}\t{:*^20}\t{:*^20}".format("Translated", "Total", "Percent", "Obsolete"))
 # loop on files
 for f in stats.keys():
-    print "\n[{}]\n".format(f)
+    print("\n[{}]\n".format(f))
     # loop on languages
     lang = stats[f].keys()
     lang.sort()
@@ -97,5 +101,5 @@ for f in stats.keys():
         stat = stats[f][l]
         total = stat["translated"] + stat["unfinished"]
         percent = float(stat["translated"]) / total * 100
-        print "--> {}:\t{:^20}\t{:^20}\t{:^20.1f}%\t{:^20}".format(l, stat["translated"], total, percent, stat["obsolete"])
-
+        print("--> {}:\t{:^20}\t{:^20}\t{:^20.1f}%\t{:^20}".format(l, stat["translated"], total, percent,
+                                                                   stat["obsolete"]))

--- a/maintainer/translations/path.py
+++ b/maintainer/translations/path.py
@@ -18,15 +18,15 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import os.path
+import sys
 
 SCRIPT_DIRECTORY = sys.path[0]
 SOURCES_DIRECTORY = os.path.join(SCRIPT_DIRECTORY, "..", "..", "aseba")
 
-QTABOUT_PATH   = os.path.join(SOURCES_DIRECTORY, "common", "about")
-STUDIO_PATH    = os.path.join(SOURCES_DIRECTORY, "clients", "studio")
-COMPILER_PATH  = os.path.join(SOURCES_DIRECTORY, "compiler")
+QTABOUT_PATH = os.path.join(SOURCES_DIRECTORY, "common", "about")
+STUDIO_PATH = os.path.join(SOURCES_DIRECTORY, "clients", "studio")
+COMPILER_PATH = os.path.join(SOURCES_DIRECTORY, "compiler")
 PLAYGROUND_PATH = os.path.join(SOURCES_DIRECTORY, "targets", "playground")
 CHALLENGE_PATH = os.path.join(SOURCES_DIRECTORY, "targets", "challenge")
 THYMIOUPGRADER_PATH = os.path.join(SOURCES_DIRECTORY, "clients", "thymioupgrader")

--- a/maintainer/translations/translation_tools.py
+++ b/maintainer/translations/translation_tools.py
@@ -18,40 +18,49 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import sys
+from __future__ import print_function
+
 import os
 import os.path
-import subprocess
 import re
+import subprocess
+import sys
+
+from six import input
 
 _lupdate = ""
 _git = ""
 
+
 def _verbose_call(cmd):
-    print cmd
+    print(cmd)
     return subprocess.call(cmd, shell=True)
+
 
 def _silent_call(cmd):
     with open(os.devnull, 'w') as tempf:
         return subprocess.call(cmd, shell=True, stdout=tempf, stderr=tempf)
 
+
 def _find_cmd(possible_cmds, args):
     for cmd in possible_cmds:
-        print "Trying... [{}]".format(cmd)
+        print("Trying... [{}]".format(cmd))
         retcode = _silent_call("{} {}".format(cmd, args))
         if retcode == 0:
-            print "OK\n"
+            print("OK\n")
             return cmd
         else:
-            print "No"
+            print("No")
     return ""
+
 
 def do_lupdate(output_name, lang_code, input_files):
     filename = "{}_{}.ts".format(output_name, lang_code)
     # _lupdate
-    retcode = _verbose_call("{} -no-recursive {} -target-language {} -locations relative -ts {}".format(_lupdate, input_files, lang_code, filename))
+    retcode = _verbose_call("{} -no-recursive {} -target-language {} -locations relative -ts {}".format(
+        _lupdate, input_files, lang_code, filename))
     if retcode != 0:
-        print sys.stderr, "Ooops... Something wrong happened with lupdate {}".format(filename)
+        print("Ooops... Something wrong happened with lupdate {}".format(filename), file=sys.stderr)
         exit(3)
     if _git:
         _verbose_call("{} add {}".format(_git, filename))
@@ -61,8 +70,8 @@ def do_lupdate_all(directory, generic_name, input_files):
     old_path = os.getcwd()
     os.chdir(directory)
     # search all the existing languages corresponding to this file
-    file_re = re.compile("{}_(\w+?).ts".format(generic_name))
-    files = [ f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f)) ]
+    file_re = re.compile(r"{}_(\w+?).ts".format(generic_name))
+    files = [f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))]
     for f in files:
         match = file_re.match(f)
         if not match:
@@ -82,18 +91,16 @@ def init_commands():
     global _lupdate
     global _git
 
-    print "First, we will test for a valid lupdate binary..."
+    print("First, we will test for a valid lupdate binary...")
     _lupdate = _find_cmd(["lupdate"], "-version")
     if _lupdate == "":
-        print sys.stderr, "No valide lupdate found :-("
+        print("No valide lupdate found :-(", file=sys.stderr)
         exit(1)
 
-    print "Trying to find a valid git binary (not mandatory)..."
+    print("Trying to find a valid git binary (not mandatory)...")
     _git = _find_cmd(["git"], "--version")
     if _git == "":
-        print "No git found, won't be able to add newly created files.\n"
+        print("No git found, won't be able to add newly created files.\n")
     else:
-        if raw_input("Git found: do you want to automatically 'git add' the files? [y/N] ") != 'y':
+        if input("Git found: do you want to automatically 'git add' the files? [y/N] ") != 'y':
             _git = ""
-
-

--- a/maintainer/updatedoc/qrc.py
+++ b/maintainer/updatedoc/qrc.py
@@ -1,9 +1,10 @@
+from __future__ import print_function
+
 import os
 import sys
 from string import Template
 
-qrc_template = \
-"""
+qrc_template = """
 <!DOCTYPE RCC><RCC version="1.0">
 <qresource>
 ${filelist}
@@ -13,20 +14,20 @@ ${filelist}
 
 item_template = """	<file>${filename}</file>\n"""
 
+
 def generate(directory, qrc_file):
     files = [x for x in os.listdir(directory)]
     files.sort()
-    print >> sys.stderr, "\nCreating {}, based on the content of {}...".format(qrc_file, directory)
+    print("\nCreating {}, based on the content of {}...".format(qrc_file, directory), file=sys.stderr)
     items = ""
     item = Template(item_template)
     qrc = Template(qrc_template)
     for x in files:
         filename = os.path.join(directory, x)
-        print >> sys.stderr, "Processing ", filename
+        print("Processing ", filename, file=sys.stderr)
         items += item.substitute(filename=filename)
 
     f = open(qrc_file, 'w')
     f.write(qrc.substitute(filelist=items))
     f.close
-    print >> sys.stderr, "Done."
-
+    print("Done.", file=sys.stderr)

--- a/maintainer/updatedoc/qthelp.py
+++ b/maintainer/updatedoc/qthelp.py
@@ -1,12 +1,12 @@
+from __future__ import print_function
+
 import os
 import sys
 from string import Template
 
 import wikidot.structure
-from wikidot.tree import WikiNode
 
-qhp_template = \
-"""<?xml version="1.0" encoding="UTF-8"?>
+qhp_template = """<?xml version="1.0" encoding="UTF-8"?>
 <QtHelpProject version="1.0">
         <namespace>aseba.main</namespace>
         <virtualFolder>doc</virtualFolder>
@@ -18,14 +18,12 @@ ${filter_section}
 </QtHelpProject>
 """
 
-filter_def_template = \
-"""        <customFilter name="${lang}">
+filter_def_template = """        <customFilter name="${lang}">
                 <filterAttribute>lang-${lang}</filterAttribute>
         </customFilter>
 """
 
-filter_section_template = \
-"""
+filter_section_template = """
         <filterSection>
                 <filterAttribute>lang-${lang}</filterAttribute>
                 <toc>
@@ -38,27 +36,21 @@ ${files}
         </filterSection>
 """
 
-
-section_root_template = \
-"""                        <section title="${title}" ref = "${ref}">
+section_root_template = """                        <section title="${title}" ref = "${ref}">
 ${subsection}
                         </section>
 """
 section_root = Template(section_root_template)
 
-
-section_leaf_template = \
-"""                                <section title="${title}" ref="${ref}"></section>
+section_leaf_template = """                                <section title="${title}" ref="${ref}"></section>
 """
 section_leaf = Template(section_leaf_template)
 
-
-file_element_template = \
-"""                        <file>${filename}</file>
+file_element_template = """                        <file>${filename}</file>
 """
 
-
 item_template = """	<file>${filename}</file>\n"""
+
 
 def __generate_sections__(node, output_directory):
     result = ""
@@ -79,12 +71,13 @@ def __generate_sections__(node, output_directory):
         result += section_root.substitute(title=node.title, ref=filename, subsection=subsections)
         return result
 
+
 def generate(source_directories, output_directory, languages, qhp_file):
     """
     directory / language should be lists
     """
 
-    print >> sys.stderr, "\nCreating {}, based on the content of {}...".format(qhp_file, source_directories)
+    print("\nCreating {}, based on the content of {}...".format(qhp_file, source_directories), file=sys.stderr)
 
     qhp = Template(qhp_template)
     filterdefs = ""
@@ -105,7 +98,7 @@ def generate(source_directories, output_directory, languages, qhp_file):
         fileitem = Template(file_element_template)
         for x in files:
             filename = os.path.join(output_directory, x)
-            #print >> sys.stderr, "Processing ", filename
+            # print ("Processing ", filename, file=sys.stderr)
             filelist += fileitem.substitute(filename=filename)
         # Generate the chunk for the current language
         filtersections += filtersection.substitute(lang=lang, files=filelist, sections=sections)
@@ -113,5 +106,4 @@ def generate(source_directories, output_directory, languages, qhp_file):
     f = open(qhp_file, 'w')
     f.write(qhp.substitute(filter_def=filterdefs, filter_section=filtersections))
     f.close
-    print >> sys.stderr, "Done."
-
+    print("Done.", file=sys.stderr)

--- a/maintainer/updatedoc/updatedoc.py
+++ b/maintainer/updatedoc/updatedoc.py
@@ -22,24 +22,22 @@
 import os
 import os.path
 import sys
-from shutil import rmtree
-from shutil import copytree
-from shutil import copy
+from shutil import copy, copytree, rmtree
 
+import qthelp
+import wikidot.structure
 # Custom lib
 from wikidot.fetch import fetchwikidot
-import wikidot.structure
-import qthelp
 
 complete_language_map = {
-                'en':'http://aseba.wikidot.com/en:asebausermanual',
-                'fr':'http://aseba.wikidot.com/fr:asebausermanual',
-                'de':'http://aseba.wikidot.com/de:asebausermanual',
-                'es':'http://aseba.wikidot.com/es:asebausermanual',
-                'it':'http://aseba.wikidot.com/it:asebausermanual'
-                # insert translation here (DO NOT REMOVE -> used by automated script)
-                }                       # used for updating help index
-language_map = complete_language_map.copy()    # used for fetching
+    'en': 'http://aseba.wikidot.com/en:asebausermanual',
+    'fr': 'http://aseba.wikidot.com/fr:asebausermanual',
+    'de': 'http://aseba.wikidot.com/de:asebausermanual',
+    'es': 'http://aseba.wikidot.com/es:asebausermanual',
+    'it': 'http://aseba.wikidot.com/it:asebausermanual'
+    # insert translation here (DO NOT REMOVE -> used by automated script)
+}  # used for updating help index
+language_map = complete_language_map.copy()  # used for fetching
 OUTPUT_DIR = 'doc'
 QHP_FILE = './aseba-doc.qhp'
 CSS_FILE = './css/aseba.css'

--- a/maintainer/updatedoc/wikidot/fetch.py
+++ b/maintainer/updatedoc/wikidot/fetch.py
@@ -18,30 +18,29 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import os.path
+import re
 # System lib
 import sys
-import os.path
 import urlparse
-import re
 
-# Custom lib
-from wikidot.tools import fetchurl
 from wikidot.fixurl import fixurls
-from wikidot.tools import tidy
-from wikidot.tools import fix_latex
-from wikidot.urltoname import urltoname
 from wikidot.orderedset import OrderedSet
+# Custom lib
+from wikidot.tools import fetchurl, fix_latex, tidy
+from wikidot.urltoname import urltoname
 
 ALTERNATE_SERVERS = {
-        'wikidot': set(['wikidot', 'wdfiles']),
-        }
+    'wikidot': set(['wikidot', 'wdfiles']),
+}
+
 
 # TODO: somewhat ugly hack...
 def _get_alternate_server(url):
     for base_server, servers in ALTERNATE_SERVERS.iteritems():
         for server in servers:
             if server in url:
-                #print "Replacing ", server, " with ", base_server, "..."
+                # print("Replacing ", server, " with ", base_server, "...")
                 return re.sub(server, base_server, url)
     # no match
     return url
@@ -51,8 +50,8 @@ def fetchwikidot(starturl, outputdir):
     # Create the output directory, if needed
     try:
         os.stat(outputdir)
-    except OSError, e:
-        print >> sys.stderr, "Creating output directory; ", outputdir
+    except OSError:
+        print("Creating output directory; ", outputdir, file=sys.stderr)
         os.mkdir(outputdir)
 
     # Fetch root page
@@ -62,7 +61,7 @@ def fetchwikidot(starturl, outputdir):
     breadcrumbs = retval['breadcrumbs']
     # get the last element of the list
     if len(breadcrumbs) > 0:
-        breadcrumbs = breadcrumbs[len(breadcrumbs)-1]
+        breadcrumbs = breadcrumbs[len(breadcrumbs) - 1]
     else:
         breadcrumbs = ''
 
@@ -80,7 +79,8 @@ def fetchwikidot(starturl, outputdir):
             # Link on the same server? If no match, search the list of alternative servers
             start_server = urlparse.urlparse(starturl).netloc
             link_server = urlparse.urlparse(url).netloc
-            if (link_server == start_server or _get_alternate_server(link_server) == _get_alternate_server(start_server)):
+            if (link_server == start_server
+                    or _get_alternate_server(link_server) == _get_alternate_server(start_server)):
                 retval = fetchurl(url, output, breadcrumbs)
                 newlinks.update(retval['links'])
             else:

--- a/maintainer/updatedoc/wikidot/fixurl.py
+++ b/maintainer/updatedoc/wikidot/fixurl.py
@@ -46,8 +46,8 @@ class FixURL(MyParser):
 
     def reset(self):
         MyParser.reset(self)
-        self.local_set = set()      # Set of local links
-        self.remote_set = set()     # Set of remote links
+        self.local_set = set()  # Set of local links
+        self.remote_set = set()  # Set of remote links
 
     # Public functions
     def get_local_links(self):
@@ -83,11 +83,11 @@ class FixURL(MyParser):
         """Private - Take a link and convert it,
         either as a local link, either as a link pointing
         to the remote host."""
-        if self.__is_link_toc__(link) == True:
+        if self.__is_link_toc__(link):
             # don't touch it!
             return link
 
-        if self.__is_link_local__(link) == True:
+        if self.__is_link_local__(link):
             # Convert link
             new_link = urltoname(link)
             self.local_set.add(new_link)
@@ -96,7 +96,6 @@ class FixURL(MyParser):
             new_link = urlparse.urljoin(self.remote_host, link)
             self.remote_set.add(new_link)
         return new_link
-
 
     # Inherited functions
     def handle_starttag(self, tag, attrs):
@@ -117,7 +116,6 @@ class FixURL(MyParser):
                     break
 
         MyParser.handle_starttag(self, tag, attrs)
-
 
 
 def fixurls(directory, base_url):
@@ -153,5 +151,3 @@ def fixurls(directory, base_url):
     print >> sys.stderr, "\nRemote URLs: "
     for x in sorted(remote_set):
         print >> sys.stderr, "  ", x
-
-

--- a/maintainer/updatedoc/wikidot/myparser.py
+++ b/maintainer/updatedoc/wikidot/myparser.py
@@ -18,6 +18,7 @@
 
 from HTMLParser import HTMLParser
 
+
 class MyParser(HTMLParser):
     """Custom HTML parser, derived from HTMLParser lib.
 
@@ -84,4 +85,3 @@ class MyParser(HTMLParser):
     def handle_decl(self, decl):
         """Overidden - Called when a SGML declaration (<!) is parsed"""
         self.out_doc += ("<!" + decl + ">")
-

--- a/maintainer/updatedoc/wikidot/orderedset.py
+++ b/maintainer/updatedoc/wikidot/orderedset.py
@@ -1,10 +1,9 @@
-
 class OrderedSet(list):
     """Naive and minimalist implementation of an ordered set"""
 
     def __init__(self, iterable=None):
         """x.__init__(...) initializes x."""
-        if iterable != None:
+        if iterable is not None:
             self.update(iterable)
 
     def __sub__(self, orderedset):

--- a/maintainer/updatedoc/wikidot/parser.py
+++ b/maintainer/updatedoc/wikidot/parser.py
@@ -18,15 +18,14 @@
 
 # Python lib
 import sys
-from myparser import MyParser
 from string import Template
 
 # Local module
 import wikidot.debug
+from myparser import MyParser
 from wikidot.orderedset import OrderedSet
 
-header = \
-"""
+header = """
 <!DOCTYPE html
      PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
      "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
@@ -44,32 +43,29 @@ header = \
 ${toc}
 """
 
-footer = \
-"""
+footer = """
 </body>
 </html>
 """
 
+
 class WikidotParser(MyParser):
     """WikidotParser is used to clean a page from www.wikidot.com,
     keeping only the interesting content."""
+
     def __init__(self):
         """Intialize internal variables"""
         MyParser.__init__(self)
         self.div_level = 0
-        self.div_bookmark = [-1]    # List managed as a stack
-        self.state = ["none"]       # List managed as a stack
-        self.current_state = "none" # Point to the top of the stack
+        self.div_bookmark = [-1]  # List managed as a stack
+        self.state = ["none"]  # List managed as a stack
+        self.current_state = "none"  # Point to the top of the stack
         # map for div tag attribute -> state
         # (attribute name, attribute property, state)
-        self.div_state_map = \
-            [
-            ('id', 'page-title', 'title'),
-            ('id', 'breadcrumbs', 'breadcrumbs'),
-            ('id', 'page-content', 'body'),
-            ('id', 'toc-action-bar', 'useless'),
-            ('id', 'toc', 'toc'),
-            ('style','position:absolute', 'useless')]
+        self.div_state_map = [('id', 'page-title', 'title'), ('id', 'breadcrumbs', 'breadcrumbs'),
+                              ('id', 'page-content', 'body'), ('id', 'toc-action-bar', 'useless'), ('id', 'toc',
+                                                                                                    'toc'),
+                              ('style', 'position:absolute', 'useless')]
         self.page_title = ""
         self.toc = ""
         self.links = OrderedSet()
@@ -111,13 +107,13 @@ class WikidotParser(MyParser):
         Depending on the current state, the start tag is queued for output,
         or not."""
         # Debug
-        if wikidot.debug.ENABLE_DEBUG == True:
+        if wikidot.debug.ENABLE_DEBUG:
             print >> sys.stderr, "<{}> {}".format(tag, attrs)
 
         # Update the state machine
         state_changed = self.__update_state_machine_start__(tag, attrs)
 
-        if (state_changed == True) and (self.current_state == "body"):
+        if state_changed and (self.current_state == "body"):
             # We have just entered the body, don't output this <div> tag
             return
         if self.current_state == "body":
@@ -147,7 +143,7 @@ class WikidotParser(MyParser):
 
         # Update the state machine
         state_changed = self.__update_state_machine_end__(tag)
-        if state_changed == True:
+        if state_changed:
             return
 
         if self.current_state == "body":
@@ -214,7 +210,7 @@ class WikidotParser(MyParser):
         state_changed = False
 
         if tag == 'div':
-            if wikidot.debug.ENABLE_DEBUG == True:
+            if wikidot.debug.ENABLE_DEBUG:
                 print >> sys.stderr, self.state, self.div_bookmark
             # Look for the id = xyz attribute
             for attr in attrs:
@@ -236,7 +232,7 @@ class WikidotParser(MyParser):
         state_changed = False
 
         if tag == 'div':
-            if wikidot.debug.ENABLE_DEBUG == True:
+            if wikidot.debug.ENABLE_DEBUG:
                 print >> sys.stderr, self.state, self.div_bookmark
             self.div_level -= 1
             if self.div_level == self.div_bookmark[-1]:
@@ -272,4 +268,3 @@ class WikidotParser(MyParser):
                     pos = attr[1].find('px')
                     if pos >= 0:
                         attrs[index] = (attr[0], attr[1][0:pos])
-

--- a/maintainer/updatedoc/wikidot/structure.py
+++ b/maintainer/updatedoc/wikidot/structure.py
@@ -16,31 +16,35 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import pickle
+import sys
 
-from wikidot.urltoname import urltoname
 from wikidot.tree import WikiNode
+from wikidot.urltoname import urltoname
 
 # Global variables used to build the wiki's structure
 __structure__ = dict()
 __lang__ = ''
+
 
 def add_language(lang):
     """Create a new entry for this language in the dictionary"""
     global __structure__
     __structure__[lang] = WikiNode('root_' + lang, '')
 
+
 def set_current_language(lang):
     """Set the current language, for future insertions"""
     global __lang__
     __lang__ = lang
 
+
 def get_structure(lang):
     """Return the tree corresponding to a specific language"""
     return __structure__[lang]
 
-def insert(title, url, breadcrumbs = set()):
+
+def insert(title, url, breadcrumbs=set()):
     """Insert a page into the current tree
 
     Set the current language using the 'set_current_language()' function."""
@@ -54,15 +58,19 @@ def insert(title, url, breadcrumbs = set()):
         page_breadcrumbs.append(urltoname(x))
     if __lang__ != '':
         __structure__[__lang__].insert(title, page_link, page_breadcrumbs)
+
+
 #        print >> sys.stderr, "**** Dump after insert:"
 #        __structure__[__lang__].dump()
     else:
         print >> sys.stderr, "*** Error in wikidot.structure.insert: set the language beforehand"
 
+
 def serialize(f):
     pickler = pickle.Pickler(f)
     pickler.dump(__lang__)
     pickler.dump(__structure__)
+
 
 def unserialize(f):
     global __lang__
@@ -70,4 +78,3 @@ def unserialize(f):
     pickler = pickle.Unpickler(f)
     __lang__ = pickler.load()
     __structure__ = pickler.load()
-

--- a/maintainer/updatedoc/wikidot/tools.py
+++ b/maintainer/updatedoc/wikidot/tools.py
@@ -16,20 +16,22 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
+import mimetypes
 # System lib
 import os
 import os.path
+import subprocess
 import sys
 import urllib2
-import mimetypes
-import subprocess
 
 # Custom lib
 import wikidot.debug
 import wikidot.structure
-from wikidot.urltoname import urltoname
-from wikidot.parser import WikidotParser
 import wikidot.tex2png
+from wikidot.parser import WikidotParser
+
 
 def __fix_breadcrumbs__(breadcrumbs, toplevel):
     # check if toplevel is part of the breadcrumbs,
@@ -45,7 +47,8 @@ def __fix_breadcrumbs__(breadcrumbs, toplevel):
             output_enable = True
     return output
 
-def fetchurl(page, offline_name, breadcrumbs = ''):
+
+def fetchurl(page, offline_name, breadcrumbs=''):
     """Given a wikidot URL, fetch it, convert it and store it locally.
 
     Inputs:
@@ -60,17 +63,17 @@ def fetchurl(page, offline_name, breadcrumbs = ''):
         # Get the page
         print >> sys.stderr, "Connecting to {}...".format(page)
         response = urllib2.urlopen(page)
-    except urllib2.HTTPError, e:
-        print >> sys.stderr, e.code
-    except urllib2.URLError, e:
-        print >> sys.stderr, e.reason
+    except urllib2.HTTPError as e:
+        print(e.code, file=sys.stderr)
+    except urllib2.URLError as e:
+        print(e.reason, file=sys.stderr)
     else:
         retval = dict()
         retval['links'] = set()
         retval['breadcrumbs'] = list()
         # Check MIME type
         mime = mimetypes.guess_type(page)[0]
-        if (mime == None) or ('html' in mime):
+        if (mime is None) or ('html' in mime):
             # HTML or unknown type
             # Convert the wikidot page and check the breakcrumbs
             print >> sys.stderr, "Parsing..."
@@ -94,7 +97,7 @@ def fetchurl(page, offline_name, breadcrumbs = ''):
             data = response.read()
         else:
             # Type is not supported
-            if wikidot.debug.ENABLE_DEBUG == True:
+            if wikidot.debug.ENABLE_DEBUG:
                 print >> sys.stderr, "*** This is not a supported type of file. File skipped."
             return retval
         # Save
@@ -102,9 +105,10 @@ def fetchurl(page, offline_name, breadcrumbs = ''):
         f = open(offline_name, 'w')
         f.write(data)
         f.close()
-        if wikidot.debug.ENABLE_DEBUG == True:
-            print >> sys.stderr, "***DEBUG: links: ", reval['links']
+        if wikidot.debug.ENABLE_DEBUG:
+            print("***DEBUG: links: ", retval['links'], file=sys.stderr)
         return retval
+
 
 def tidy(directory):
     html_files = [x for x in os.listdir(directory) if '.html' in x]
@@ -112,7 +116,8 @@ def tidy(directory):
     for x in html_files:
         filename = os.path.join(directory, x)
         print >> sys.stderr, "Processing ", filename
-        retcode = subprocess.call(["tidy","-config", "wikidot/tidy.config", "-q", "-o", filename, filename])
+        subprocess.call(["tidy", "-config", "wikidot/tidy.config", "-q", "-o", filename, filename])
+
 
 def fix_latex(directory):
     """Given a directory, convert LaTeX code to PNG images for every HTML file.
@@ -129,4 +134,3 @@ def fix_latex(directory):
         filename = os.path.join(directory, x)
         print >> sys.stderr, "Processing ", filename
         wikidot.tex2png.from_html(filename, os.path.splitext(filename)[0])
-

--- a/maintainer/updatedoc/wikidot/tree.py
+++ b/maintainer/updatedoc/wikidot/tree.py
@@ -18,6 +18,7 @@
 
 import sys
 
+
 class WikiNode:
     """Build a tree, mirroring the structure of a wikidot-based wiki"""
 
@@ -75,4 +76,3 @@ class WikiNode:
         level += 1
         for x in self.children:
             x.dump(level)
-

--- a/maintainer/updatedoc/wikidot/urltoname.py
+++ b/maintainer/updatedoc/wikidot/urltoname.py
@@ -16,8 +16,9 @@
 #   You should have received a copy of the GNU Lesser General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import urlparse
 import os.path
+import urlparse
+
 
 def urltoname(page):
     o = urlparse.urlparse(page)
@@ -28,5 +29,3 @@ def urltoname(page):
     if os.path.splitext(name)[1] == '':
         name += '.html'
     return name
-
-

--- a/menu/src/generate-pixmaps.py
+++ b/menu/src/generate-pixmaps.py
@@ -1,57 +1,62 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 import glob
 import os
-import sys
 import subprocess
+import sys
 
 # note: to be launched from where the svg files are
 #       this script requires inkscape, imagemagick and makeicns
 
+
 def cmd_exists(cmd):
-	return subprocess.call("type " + cmd, shell=True, 
-		stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
+    return subprocess.call("type " + cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
+
 
 if __name__ == '__main__':
-	if not cmd_exists('inkscape'):
-		print 'Install Inkscape!'
-		sys.exit(1)
-	if not cmd_exists('convert'):
-		print 'convert not found, Windows icons generation disabled'
-	if not cmd_exists('makeicns'):
-		print 'makeicns not found, OS X icons generation disabled'
-	
-	for file in glob.glob('*.svg'):
-		
-		def convert(target_dir, target_size, add=''):
-			source_file = os.path.join(os.getcwd(), file)
-			target_file = os.path.join(os.getcwd(), target_dir, os.path.splitext(file)[0] + add + '.png')
-			print source_file
-			print target_file
-			cmd = 'inkscape --export-png={0} --export-width={1} --export-height={1} {2}'
-			os.system(cmd.format(target_file, target_size, source_file))
-		
-		base_source_file = os.path.splitext(file)[0]
-		print 'Processing ' + base_source_file
-		
-		print 'Generating freedesktop files'
-		convert('../freedesktop/48x48', '48')
-		
-		if cmd_exists('convert'):
-			print 'Generating Windows ico'
-			convert('../windows/', '256', '-256')
-			convert('../windows/', '48', '-48')
-			os.system('convert ../windows/{0}-48.png ../windows/{0}-256.png ../windows/{0}.ico'.format(base_source_file))
-			os.system('rm ../windows/{0}-48.png ../windows/{0}-256.png'.format(base_source_file))
-		
-		if cmd_exists('makeicns'):
-			print 'Generating OS X icns'
-			convert('../osx/', '512', '-512')
-			convert('../osx/', '256', '-256')
-			convert('../osx/', '128', '-128')
-			convert('../osx/', '32', '-32')
-			convert('../osx/', '16', '-16')
-			os.system('makeicns -512 ../osx/{0}-512.png -256 ../osx/{0}-256.png -128 ../osx/{0}-128.png -32 ../osx/{0}-32.png -16 ../osx/{0}-16.png -out ../osx/{0}.icns'.format(base_source_file))
-			os.system('rm ../osx/{0}-*.png'.format(base_source_file))
+    if not cmd_exists('inkscape'):
+        print('Install Inkscape!')
+        sys.exit(1)
+    if not cmd_exists('convert'):
+        print('convert not found, Windows icons generation disabled')
+    if not cmd_exists('makeicns'):
+        print('makeicns not found, OS X icons generation disabled')
 
+    for file in glob.glob('*.svg'):
+
+        def convert(target_dir, target_size, add=''):
+            source_file = os.path.join(os.getcwd(), file)
+            target_file = os.path.join(os.getcwd(), target_dir, os.path.splitext(file)[0] + add + '.png')
+            print(source_file)
+            print(target_file)
+            cmd = 'inkscape --export-png={0} --export-width={1} --export-height={1} {2}'
+            os.system(cmd.format(target_file, target_size, source_file))
+
+        base_source_file = os.path.splitext(file)[0]
+        print('Processing ' + base_source_file)
+
+        print('Generating freedesktop files')
+        convert('../freedesktop/48x48', '48')
+
+        if cmd_exists('convert'):
+            print('Generating Windows ico')
+            convert('../windows/', '256', '-256')
+            convert('../windows/', '48', '-48')
+            os.system(
+                'convert ../windows/{0}-48.png ../windows/{0}-256.png ../windows/{0}.ico'.format(base_source_file))
+            os.system('rm ../windows/{0}-48.png ../windows/{0}-256.png'.format(base_source_file))
+
+        if cmd_exists('makeicns'):
+            print('Generating OS X icns')
+            convert('../osx/', '512', '-512')
+            convert('../osx/', '256', '-256')
+            convert('../osx/', '128', '-128')
+            convert('../osx/', '32', '-32')
+            convert('../osx/', '16', '-16')
+            os.system(
+                'makeicns -512 ../osx/{0}-512.png -256 ../osx/{0}-256.png -128 ../osx/{0}-128.png -32 ../osx/{0}-32.png -16 ../osx/{0}-16.png -out ../osx/{0}.icns'
+                .format(base_source_file))
+            os.system('rm ../osx/{0}-*.png'.format(base_source_file))

--- a/tests/compiler/fuzzyinput.py
+++ b/tests/compiler/fuzzyinput.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 
-import sys
+from __future__ import print_function
+
 import os
 import subprocess
+import sys
 
-iterations = 100    # by default
+iterations = 100  # by default
 fuzzy_ratio = 0.01
 
 # When executed from the command line
@@ -18,15 +20,15 @@ if __name__ == "__main__":
         if len(sys.argv) == 4:
             iterations = int(sys.argv[3])
     else:
-        print >> sys.stderr, "Wrong number of arguments.\n"
-        print >> sys.stderr, "Usage:"
-        print >> sys.stderr, "  {} asebatest_bin input_script".format(sys.argv[0])
+        print("Wrong number of arguments.\n", file=sys.stderr)
+        print("Usage:", file=sys.stderr)
+        print("  {} asebatest_bin input_script".format(sys.argv[0]), file=sys.stderr)
         exit(1)
 
 try:
     f = open(input_script, 'rb')
-except IOError, e:
-    print "Can not find the script file {}. Error.".format(input_script)
+except IOError:
+    print("Can not find the script file {}. Error.".format(input_script))
     exit(2)
 
 # read the script
@@ -35,20 +37,27 @@ f.close()
 
 # run several fuzzing loops, changing the seed at each step
 failed = False
-for s in range(0,iterations):
-    #subprocess.call(["zzuf", "-P", r"\n", "-R", r"\x00-\x1f\x7f-\xff", "-r{}".format(fuzzy_ratio), "-s", str(s), "cat", input_script])
-    retcode = subprocess.call(["zzuf", "-P", r"\n", "-R", r"\x00-\x1f\x7f-\xff", "-r".format(fuzzy_ratio), "-s", str(s), asebatest_bin, input_script], \
-            stdout=open(os.devnull), stderr=open(os.devnull))
+for s in range(0, iterations):
+    # subprocess.call(["zzuf", "-P", r"\n", "-R", r"\x00-\x1f\x7f-\xff", "-r{}".format(fuzzy_ratio),
+    # "-s", str(s), "cat", input_script])
+    retcode = subprocess.call([
+        "zzuf", "-P", r"\n", "-R", r"\x00-\x1f\x7f-\xff", "-r".format(fuzzy_ratio), "-s",
+        str(s), asebatest_bin, input_script
+    ],
+                              stdout=open(os.devnull),
+                              stderr=open(os.devnull))
     if retcode == 1:
         # oops, the child of zzuf crashed (sigsev?)
-        print >> sys.stderr, "Compiler crached when fuzzing the input script."
-        print >> sys.stderr, "Faulty script is generated with the seed (-s) {}:".format(s)
-        subprocess.call(["zzuf", "-P", r"\n", "-R", r"\x00-\x1f\x7f-\xff", "-r{}".format(fuzzy_ratio), "-s", str(s), "cat", input_script])
+        print("Compiler crached when fuzzing the input script.", file=sys.stderr)
+        print("Faulty script is generated with the seed (-s) {}:".format(s), file=sys.stderr)
+        subprocess.call([
+            "zzuf", "-P", r"\n", "-R", r"\x00-\x1f\x7f-\xff", "-r{}".format(fuzzy_ratio), "-s",
+            str(s), "cat", input_script
+        ])
         failed = True
         break
 
-if failed == True:
+if failed:
     exit(3)
 else:
     exit(0)
-

--- a/tests/compiler/simulateuser.py
+++ b/tests/compiler/simulateuser.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
-import sys
+from __future__ import print_function
+
 import os
-import tempfile
 import subprocess
+import sys
+import tempfile
 
 # When executed from the command line
 if __name__ == "__main__":
@@ -14,15 +16,15 @@ if __name__ == "__main__":
         asebatest_bin = sys.argv[1]
         input_script = sys.argv[2]
     else:
-        print >> sys.stderr, "Wrong number of arguments.\n"
-        print >> sys.stderr, "Usage:"
-        print >> sys.stderr, "  {} asebatest_bin input_script".format(sys.argv[0])
+        print("Wrong number of arguments.\n", file=sys.stderr)
+        print("Usage:", file=sys.stderr)
+        print("  {} asebatest_bin input_script".format(sys.argv[0]), file=sys.stderr)
         exit(1)
 
 try:
     f = open(input_script, 'rb')
-except IOError, e:
-    print "Can not find the script file {}. Error.".format(input_script)
+except IOError:
+    print("Can not find the script file {}. Error.".format(input_script))
     exit(2)
 
 # read the script
@@ -38,7 +40,7 @@ tmp_script = ''
 failed = False
 for c in script:
     # generate the incremental script
-    tmp_script += c
+    tmp_script += str(c)
     # write to temp file
     tmp = open(tmp.name, 'wb')
     tmp.write(script)
@@ -47,16 +49,15 @@ for c in script:
     retcode = subprocess.call([asebatest_bin, tmp.name], stdout=open(os.devnull), stderr=open(os.devnull))
     if retcode < 0:
         # oops, received a signal (sigsev?)
-        print >> sys.stderr, "Compiler crached for the following code:"
-        print >> sys.stderr, tmp_script
+        print("Compiler crached for the following code:", file=sys.stderr)
+        print(tmp_script, file=sys.stderr)
         failed = True
         break
 
 # remove the temp file
 os.unlink(tmp.name)
 
-if failed == True:
+if failed:
     exit(retcode)
 else:
     exit(0)
-

--- a/tests/compiler/valgrind.py
+++ b/tests/compiler/valgrind.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
+import glob
+import os
+import os.path
+import re
+import stat
+import subprocess
+import sys
+# create a process pool
+from multiprocessing import Pool
+
 # This function performs a valgrind (leak-check) on asebatest with the specified script
 # If script is a directory, perform the test on all the .txt files inside this directory
 # Return 0 on success (no definitely or indirectly lost blocks), non-zero on error
-
-import sys
-import os
-import os.path
-import stat
-import glob
-import subprocess
 
 # Input arguments
 asebatest_bin = None
@@ -18,9 +23,9 @@ if len(sys.argv) == 3:
     asebatest_bin = sys.argv[1]
     input_scripts = sys.argv[2]
 else:
-    print >> sys.stderr, "Wrong number of arguments.\n"
-    print >> sys.stderr, "Usage:"
-    print >> sys.stderr, "  {} asebatest_bin input_script".format(sys.argv[0])
+    print("Wrong number of arguments.\n", file=sys.stderr)
+    print("Usage:", file=sys.stderr)
+    print("  {} asebatest_bin input_script".format(sys.argv[0]), file=sys.stderr)
     exit(1)
 
 # input_scripts: single file, or directory?
@@ -32,14 +37,12 @@ if stat.S_ISDIR(s.st_mode):
 else:
     input_scripts = [input_scripts]
 
-
-import re
-
 valgrind_num = r"([\d',]+)"
 
 definitely_lost_re = re.compile(r"definitely lost: " + valgrind_num)
 indirectly_lost_re = re.compile(r"indirectly lost: " + valgrind_num)
-possibly_lost_re = re.compile(r"possibly lost: " + valgrind_num)
+# possibly_lost_re = re.compile(r"possibly lost: " + valgrind_num)
+
 
 def search_number(string, regexp):
     # convenient function to search a number with a regex
@@ -48,11 +51,13 @@ def search_number(string, regexp):
     if match:
         return int(match.group(1).translate(None, ',\''))
 
+
 #
 def valgrind_test(input_script):
-    print "Processing {}...".format(input_script)
+    print("Processing {}...".format(input_script))
     try:
-        valgrind_output = subprocess.check_output(["valgrind", "--leak-check=summary", asebatest_bin, input_script], stderr=subprocess.STDOUT)
+        valgrind_output = subprocess.check_output(["valgrind", "--leak-check=summary", asebatest_bin, input_script],
+                                                  stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         # Non-zero exit status. With valgrind, it is the return code of the checked binary
         # return code can be cheched with e.returncode
@@ -60,20 +65,19 @@ def valgrind_test(input_script):
 
     definitely_lost = search_number(valgrind_output, definitely_lost_re)
     indirectly_lost = search_number(valgrind_output, indirectly_lost_re)
-    possibly_lost = search_number(valgrind_output, possibly_lost_re)
+    # possibly_lost = search_number(valgrind_output, possibly_lost_re)
 
     if definitely_lost > 0 or indirectly_lost > 0:
-        print "***"
-        print "{} failed: {} bytes definitely lost, {} bytes indirectly lost".format(input_script, definitely_lost, indirectly_lost)
-        print "  for details run: valgrind --leak-check=full {} {}".format(asebatest_bin, input_script)
-        print "***"
-        return True # failed
+        print("***")
+        print("{} failed: {} bytes definitely lost, {} bytes indirectly lost".format(
+            input_script, definitely_lost, indirectly_lost))
+        print("  for details run: valgrind --leak-check=full {} {}".format(asebatest_bin, input_script))
+        print("***")
+        return True  # failed
     else:
-        return False # no memleak
+        return False  # no memleak
 
 
-# create a process pool
-from multiprocessing import Pool
 pool = Pool()
 
 # test all the scripts using the process pool
@@ -83,4 +87,3 @@ if True in failed:
     exit(2)
 else:
     exit(0)
-


### PR DESCRIPTION
Hi again,

This PR follows https://github.com/enki-community/enki/pull/61 & https://github.com/enki-community/enki/pull/62 and fixes #888 

As in https://github.com/enki-community/enki/pull/62, to ensure that there is no syntax errors in python scripts neither in python2 nor 3, I used the flake8 linter with `python2 -m flake8` and `python3 -m flake8`.

I also ran the full test suite with success with both python versions.

Most changes are:
- whitespaces, around operators, after a #, and some tabs have been replaced by spaces. To see this PR more clearly, you can ignore this by [adding ?w=1 at the end of the url](https://github.com/aseba-community/aseba/pull/889/files?w=1)
- using the print function
- removing unused imports
- splitting lines that are too long
- changing `if var == True:` into `if var:`
- changing `if var {!,=}= None` into `if var is {not,} None` 
- using [six](https://pypi.org/project/six/) for `raw_input` and `basestring`
- relatively importing  maintainer/translations/path.py, and removing the wildcard import

[isort](https://pypi.org/project/isort/) and [yapf](https://github.com/google/yapf) have also been helping a bit, and they have made aesthetic choices you might not be comfortable with. If this is the case, I can obviously revert that to the previous format that you did prefer.

NB: u-strings have not been removed, therefore this will not work on python3 < 3.3, but most distributions provide >= 3.4.

PS: This is a Work In Progress, as there is no point in merging this PR before those that enable python3 build in enki